### PR TITLE
Fix CLI version mismatch: use dynamic import instead of hardcoded 1.1.3

### DIFF
--- a/panther/cli_click/__init__.py
+++ b/panther/cli_click/__init__.py
@@ -5,7 +5,7 @@ Modern CLI implementation using Click framework for improved user experience,
 better error handling, and enhanced maintainability.
 """
 
-from .core.main import cli
+from panther import __version__
 
-__version__ = "1.1.3"
+from .core.main import cli
 __all__ = ["cli"]

--- a/panther/cli_click/core/main.py
+++ b/panther/cli_click/core/main.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import click
 from termcolor import colored
 
+from panther import __version__
 from panther.cli_click.core.base import setup_logging
 
 
@@ -30,7 +31,7 @@ from panther.cli_click.core.base import setup_logging
     help="Enable debug logging with detailed output",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
-@click.version_option(version="1.1.3", prog_name="panther")
+@click.version_option(version=__version__, prog_name="panther")
 @click.pass_context
 def cli(ctx, debug, verbose):
     """

--- a/tests/cli_click/unit/core/test_main.py
+++ b/tests/cli_click/unit/core/test_main.py
@@ -8,6 +8,7 @@ completion functionality, and command registration.
 import pytest
 from click.testing import CliRunner
 
+from panther import __version__
 from panther.cli_click.core.main import cli, main, register_commands
 
 
@@ -26,7 +27,7 @@ class TestMainCLI:
         """Test version option displays correct version."""
         result = cli_runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "1.1.3" in result.output
+        assert __version__ in result.output
         assert "panther" in result.output
 
     def test_cli_debug_flag(self, cli_runner):
@@ -230,4 +231,4 @@ class TestCLIOutput:
         assert result.exit_code == 0
         # Should contain both program name and version
         assert "panther" in result.output.lower()
-        assert "1.1.3" in result.output
+        assert __version__ in result.output


### PR DESCRIPTION
## Summary

- Replace hardcoded `__version__ = "1.1.3"` across the Click CLI with dynamic imports from `panther.__version__`, which reads from `pyproject.toml` via `importlib.metadata`
- Eliminates version drift between `pyproject.toml` (source of truth, `1.1.5`) and the CLI output

## Changes

**`panther/cli_click/core/main.py`** (commit 1)
- Import `__version__` from `panther` and use it in `@click.version_option`

**`panther/cli_click/__init__.py`** (commit 2)
- Replace `__version__ = "1.1.3"` with `from panther import __version__`

**`tests/cli_click/unit/core/test_main.py`** (commit 2)
- Replace hardcoded `"1.1.3"` assertions with dynamic `__version__` checks so tests are version-agnostic

## Version chain after fix

```
pyproject.toml (1.1.5)
  -> importlib.metadata.version("panther-net")
    -> panther/__init__.py (__version__)
      -> panther/cli_click/__init__.py (re-export)
      -> panther/cli_click/core/main.py (Click --version)
```

## Test plan

- [x] `panther --version` reports `panther, version 1.1.5`
- [x] `python -c "from panther.cli_click import __version__; print(__version__)"` prints `1.1.5`
- [x] `pytest tests/cli_click/unit/core/test_main.py -k version` — both version tests pass
- [x] `grep -rn "1.1.3" panther/ tests/` — no stale references remain

## Summary by Sourcery

Align CLI-reported version with the package version by wiring Click's version option and CLI exports to use the central __version__ value.

Bug Fixes:
- Fix CLI version output so it always reflects the package version instead of a hardcoded string.

Tests:
- Update CLI version tests to assert against the dynamic __version__ value rather than a specific hardcoded version string.