### PR TITLE
ci: add gh-pages deployment on push to production

### DIFF
--- a/.github/workflows/pr-generate-docs.yaml
+++ b/.github/workflows/pr-generate-docs.yaml
@@ -1,5 +1,8 @@
 name: mkdocs
 on:
+  push:
+    branches:
+      - "production"
   pull_request:
     branches:
       - "production"
@@ -32,6 +35,10 @@ jobs:
         run: |
           mkdocs build --strict --config-file mkdocs.yml
       - name: "Commit generated documentation"
+        if: github.event_name == 'pull_request'
         uses: "stefanzweifel/git-auto-commit-action@v4"
         with:
           commit_message: "Updating documentation"
+      - name: "Deploy to GitHub Pages"
+        if: github.event_name == 'push'
+        run: mkdocs gh-deploy --force --config-file mkdocs.yml


### PR DESCRIPTION
The docs workflow only ran on PRs and never deployed to gh-pages. Add push trigger for production branch and mkdocs gh-deploy step so documentation updates automatically after merge.

## Summary by Sourcery

Configure the documentation workflow to both validate docs on pull requests and deploy them on pushes to the production branch.

CI:
- Trigger the mkdocs workflow on pushes to the production branch in addition to pull requests.
- Deploy the built documentation to GitHub Pages via mkdocs gh-deploy on production pushes while keeping auto-commit of generated docs limited to pull requests.