### PR TITLE
feat(config): add field constraints, enums, and metadata to config models

### DIFF
--- a/panther/config/core/components/field_coercion.py
+++ b/panther/config/core/components/field_coercion.py
@@ -1,17 +1,16 @@
-"""Standalone validation functions for direct use in PANTHER configuration code.
+"""Standalone field coercion functions for direct use in PANTHER configuration code.
 
-This module provides pure validation functions that accept a value and field name,
+This module provides pure validation/coercion functions that accept a value and field name,
 then return the validated/converted result or raise ``ValueError``. They are intended
 for imperative call-sites where you need to validate a single value outside of a
 Pydantic model context.
 
-Contrast with ``panther.config.core.validators.universal_validators``, which provides
-*factory functions* that return Pydantic-compatible validator callables (suitable for
-use with ``@field_validator`` or ``@validator`` decorators on Pydantic models).
+Contrast with ``panther.config.core.validators.pydantic_factories``, which provides
+*factory functions* that return Pydantic-compatible validator callables.
 
 Typical usage::
 
-    from panther.config.core.components.universal_validators import (
+    from panther.config.core.components.field_coercion import (
         validate_integer_field,
         validate_time_field,
         validate_enum_field,
@@ -20,13 +19,6 @@ Typical usage::
 
     port = validate_integer_field(raw_value, "port")
     timeout = validate_time_field(raw_value, "timeout")
-    level = validate_enum_field(raw_value, "level", ["debug", "info", "warning"])
-    enabled = validate_boolean_field(raw_value, "enabled")
-
-Each function:
-- Accepts flexible input types (str, int, float, etc.) and coerces them.
-- Logs warnings via the ``logging`` module when lossy conversions occur.
-- Raises ``ValueError`` with a descriptive message on invalid input.
 """
 
 import logging

--- a/panther/config/core/components/validators.py
+++ b/panther/config/core/components/validators.py
@@ -521,7 +521,10 @@ class CompatibilityValidator(BaseValidator):
     """Validator for checking legacy format compatibility."""
 
     def validate(self, config: Any) -> ValidationResult:
-        """Check for legacy format issues.
+        """Validate configuration compatibility.
+
+        All legacy format checks have been removed. This validator is retained
+        as an extension point for future compatibility checks.
 
         Args:
             config: Configuration to validate
@@ -529,29 +532,4 @@ class CompatibilityValidator(BaseValidator):
         Returns:
             Validation result
         """
-        result = ValidationResult()
-
-        # Check for deprecated fields
-        deprecated_fields = {
-            "use_docker": "docker.enabled",
-            "log_level": "logging.level",
-            "output_directory": "paths.output_dir",
-        }
-
-        config_dict = config if isinstance(config, dict) else config.to_dict()
-
-        for old_field, new_field in deprecated_fields.items():
-            if old_field in config_dict:
-                result.add_warning(
-                    old_field,
-                    f"Deprecated field '{old_field}', use '{new_field}' instead",
-                )
-
-        # Check for legacy structure
-        if "config" in config_dict and isinstance(config_dict["config"], dict):
-            result.add_warning(
-                "config",
-                "Legacy nested 'config' structure detected, consider flattening",
-            )
-
-        return result
+        return ValidationResult()

--- a/panther/config/core/models/environment.py
+++ b/panther/config/core/models/environment.py
@@ -18,9 +18,20 @@ class EnvironmentConfig(BaseConfig):
         True, description="Enable background monitoring"
     )
     monitoring_interval_seconds: int = Field(
-        5, description="Monitoring interval in seconds"
+        5,
+        ge=1,
+        le=3600,
+        description="Monitoring interval in seconds",
+        examples=[5, 10, 30],
+        json_schema_extra={"unit": "seconds"},
     )
-    failure_threshold_count: int = Field(1, description="Failure threshold count")
+    failure_threshold_count: int = Field(
+        1,
+        ge=1,
+        le=100,
+        description="Failure threshold count",
+        examples=[1, 3, 5],
+    )
     allow_partial_deployment: bool = Field(
         False, description="Allow partial deployment"
     )

--- a/panther/config/core/models/experiment.py
+++ b/panther/config/core/models/experiment.py
@@ -15,18 +15,17 @@ class StepsConfig(BaseConfig):
     pre_commands: List[str] = Field(
         default_factory=list, description="Commands to run before test"
     )
-    wait: int = Field(60, description="Wait time in seconds")
+    wait: int = Field(
+        60,
+        ge=1,
+        le=86400,
+        description="Wait time between steps in seconds",
+        examples=[30, 60, 120, 300],
+        json_schema_extra={"unit": "seconds"},
+    )
     post_commands: List[str] = Field(
         default_factory=list, description="Commands to run after test"
     )
-
-    @field_validator("wait")
-    @classmethod
-    def validate_wait(cls, v):
-        """Validate wait time is positive."""
-        if v <= 0:
-            raise ValueError("Wait time must be positive")
-        return v
 
 
 class ExperimentMetadata(BaseConfig):
@@ -44,7 +43,12 @@ class ExperimentMetadata(BaseConfig):
 class TestConfig(BaseConfig):
     """Individual test configuration."""
 
-    name: str = Field(..., description="Test name")
+    name: str = Field(
+        ...,
+        min_length=1,
+        description="Test name",
+        examples=["quic-handshake", "http3-transfer"],
+    )
     description: Optional[str] = Field(None, description="Test description")
     network_environment: NetworkEnvironmentConfig = Field(
         ..., description="Network environment configuration"
@@ -56,8 +60,21 @@ class TestConfig(BaseConfig):
         ..., description="Service configurations"
     )
     steps: StepsConfig = Field(default_factory=StepsConfig, description="Test steps")
-    iterations: int = Field(1, description="Number of iterations")
-    timeout: Optional[int] = Field(None, description="Test timeout in seconds")
+    iterations: int = Field(
+        1,
+        ge=1,
+        le=1000,
+        description="Number of test iterations",
+        examples=[1, 5, 10],
+    )
+    timeout: Optional[int] = Field(
+        None,
+        ge=1,
+        le=86400,
+        description="Test timeout in seconds",
+        examples=[60, 120, 300],
+        json_schema_extra={"unit": "seconds"},
+    )
     fast_fail_enabled: Optional[bool] = Field(
         None, description="Override fast-fail for this test"
     )
@@ -65,22 +82,6 @@ class TestConfig(BaseConfig):
         False, description="Continue test on service failures"
     )
     collect_artifacts: bool = Field(True, description="Collect test artifacts")
-
-    @field_validator("iterations")
-    @classmethod
-    def validate_iterations(cls, v):
-        """Validate iterations is positive."""
-        if v <= 0:
-            raise ValueError("Iterations must be positive")
-        return v
-
-    @field_validator("timeout")
-    @classmethod
-    def validate_timeout(cls, v):
-        """Validate timeout is positive if set."""
-        if v is not None and v <= 0:
-            raise ValueError("Timeout must be positive")
-        return v
 
     @field_validator("services")
     @classmethod

--- a/panther/config/core/models/global_config.py
+++ b/panther/config/core/models/global_config.py
@@ -21,36 +21,75 @@ class LoggingLevel(str, Enum):
     CRITICAL = "CRITICAL"
 
 
+class DockerNetworkMode(str, Enum):
+    """Docker network mode."""
+
+    BRIDGE = "bridge"
+    HOST = "host"
+    NONE = "none"
+    OVERLAY = "overlay"
+
+
+class ExportFormat(str, Enum):
+    """Metrics/data export format."""
+
+    JSON = "json"
+    CSV = "csv"
+    PROMETHEUS = "prometheus"
+
+
 class FeatureLogLevelsConfig(BaseConfig):
     """Feature-specific log level configuration."""
 
-    docker_build: Optional[str] = Field(None, description="Docker build operations")
-    service_start: Optional[str] = Field(None, description="Service startup operations")
-    environment_setup: Optional[str] = Field(None, description="Environment setup")
-    test_execution: Optional[str] = Field(None, description="Test execution")
-    metrics_collection: Optional[str] = Field(None, description="Metrics collection")
-    event_processing: Optional[str] = Field(None, description="Event processing")
-    plugin_loading: Optional[str] = Field(None, description="Plugin loading")
-    configuration: Optional[str] = Field(None, description="Configuration operations")
-    validation: Optional[str] = Field(None, description="Validation operations")
-    command_generation: Optional[str] = Field(None, description="Command generation")
-    output_collection: Optional[str] = Field(None, description="Output collection")
-    error_handling: Optional[str] = Field(None, description="Error handling")
-    fast_fail: Optional[str] = Field(None, description="Fast-fail system")
-    observer: Optional[str] = Field(None, description="Observer system")
-    state_management: Optional[str] = Field(None, description="State management")
-    service_managers: Optional[str] = Field(
+    docker_build: Optional[LoggingLevel] = Field(
+        None, description="Docker build operations"
+    )
+    service_start: Optional[LoggingLevel] = Field(
+        None, description="Service startup operations"
+    )
+    environment_setup: Optional[LoggingLevel] = Field(
+        None, description="Environment setup"
+    )
+    test_execution: Optional[LoggingLevel] = Field(None, description="Test execution")
+    metrics_collection: Optional[LoggingLevel] = Field(
+        None, description="Metrics collection"
+    )
+    event_processing: Optional[LoggingLevel] = Field(
+        None, description="Event processing"
+    )
+    plugin_loading: Optional[LoggingLevel] = Field(None, description="Plugin loading")
+    configuration: Optional[LoggingLevel] = Field(
+        None, description="Configuration operations"
+    )
+    validation: Optional[LoggingLevel] = Field(
+        None, description="Validation operations"
+    )
+    command_generation: Optional[LoggingLevel] = Field(
+        None, description="Command generation"
+    )
+    output_collection: Optional[LoggingLevel] = Field(
+        None, description="Output collection"
+    )
+    error_handling: Optional[LoggingLevel] = Field(None, description="Error handling")
+    fast_fail: Optional[LoggingLevel] = Field(None, description="Fast-fail system")
+    observer: Optional[LoggingLevel] = Field(None, description="Observer system")
+    state_management: Optional[LoggingLevel] = Field(
+        None, description="State management"
+    )
+    service_managers: Optional[LoggingLevel] = Field(
         None, description="Service manager operations"
     )
 
     @field_validator("*", mode="before")
+    @classmethod
     def validate_log_level(cls, v):
-        """Validate log level values."""
+        """Validate and convert log level values to LoggingLevel enum."""
         if v is not None and isinstance(v, str):
             try:
-                LoggingLevel(v.upper())
+                return LoggingLevel(v.upper())
             except ValueError:
-                raise ValueError(f"Invalid log level: {v}")
+                valid = [e.value for e in LoggingLevel]
+                raise ValueError(f"Invalid log level: '{v}'. Valid values are: {valid}")
         return v
 
     def to_dict(self, **kwargs) -> Dict[str, Any]:
@@ -98,8 +137,22 @@ class DockerUserMappingConfig(BaseConfig):
     """Docker user mapping configuration."""
 
     run_as_host_user: bool = Field(False, description="Run containers as host user")
-    custom_uid: Optional[int] = Field(None, description="Custom user ID")
-    custom_gid: Optional[int] = Field(None, description="Custom group ID")
+    custom_uid: Optional[int] = Field(
+        None,
+        ge=0,
+        le=65534,
+        description="Custom user ID",
+        examples=[1000, 0],
+        json_schema_extra={"category": "docker"},
+    )
+    custom_gid: Optional[int] = Field(
+        None,
+        ge=0,
+        le=65534,
+        description="Custom group ID",
+        examples=[1000, 0],
+        json_schema_extra={"category": "docker"},
+    )
     user_name: str = Field("panther", description="Container user name")
     fallback_to_root: bool = Field(
         True, description="Fallback to root if user creation fails"
@@ -142,7 +195,24 @@ class DockerConfig(BaseConfig):
         default_factory=dict, description="Build arguments"
     )
     cache_from: Optional[str] = Field(None, description="Cache source for builds")
-    network_mode: str = Field("bridge", description="Docker network mode")
+    network_mode: DockerNetworkMode = Field(
+        DockerNetworkMode.BRIDGE,
+        description="Docker network mode",
+        examples=["bridge", "host", "none"],
+        json_schema_extra={"category": "docker"},
+    )
+
+    @field_validator("network_mode", mode="before")
+    @classmethod
+    def validate_network_mode(cls, v):
+        """Convert string to DockerNetworkMode enum."""
+        if isinstance(v, str):
+            try:
+                return DockerNetworkMode(v.lower())
+            except ValueError:
+                valid = [e.value for e in DockerNetworkMode]
+                raise ValueError(f"Invalid network mode '{v}'. Valid: {valid}")
+        return v
 
     # Docker Buildx configuration fields
     use_buildx: bool = Field(
@@ -226,7 +296,12 @@ class ProgressConfig(BaseConfig):
     show_test_status: bool = Field(True, description="Show test status information")
     use_emojis: bool = Field(True, description="Use emojis in progress display")
     update_interval: float = Field(
-        0.1, description="Progress update interval (seconds)"
+        0.1,
+        ge=0.01,
+        le=10.0,
+        description="Progress update interval (seconds)",
+        examples=[0.1, 0.5, 1.0],
+        json_schema_extra={"unit": "seconds"},
     )
 
 
@@ -243,7 +318,11 @@ class FastFailConfig(BaseConfig):
         True, description="Fail on Ivy compilation errors"
     )
     timeout_cascade_threshold: int = Field(
-        1, description="Consecutive timeouts before failing"
+        1,
+        ge=1,
+        le=100,
+        description="Consecutive timeouts before failing",
+        examples=[1, 3, 5],
     )
     critical_only: bool = Field(False, description="Only fail on critical errors")
 
@@ -253,9 +332,40 @@ class MetricsConfig(BaseConfig):
 
     enabled: bool = Field(True, description="Enable metrics collection")
     collect_system_metrics: bool = Field(True, description="Collect system metrics")
-    publish_interval: int = Field(30, description="Metrics publish interval (seconds)")
-    export_format: str = Field("json", description="Export format")
-    retention_days: int = Field(30, description="Metrics retention period")
+    publish_interval: int = Field(
+        30,
+        ge=1,
+        le=3600,
+        description="Metrics publish interval (seconds)",
+        examples=[10, 30, 60],
+        json_schema_extra={"unit": "seconds"},
+    )
+    export_format: ExportFormat = Field(
+        ExportFormat.JSON,
+        description="Export format for metrics data",
+        examples=["json", "csv", "prometheus"],
+        json_schema_extra={"category": "output"},
+    )
+    retention_days: int = Field(
+        30,
+        ge=1,
+        le=365,
+        description="Metrics retention period (days)",
+        examples=[7, 30, 90],
+        json_schema_extra={"unit": "days"},
+    )
+
+    @field_validator("export_format", mode="before")
+    @classmethod
+    def validate_export_format(cls, v):
+        """Convert string to ExportFormat enum."""
+        if isinstance(v, str):
+            try:
+                return ExportFormat(v.lower())
+            except ValueError:
+                valid = [e.value for e in ExportFormat]
+                raise ValueError(f"Invalid export format '{v}'. Valid: {valid}")
+        return v
 
 
 class GlobalConfig(BaseConfig):

--- a/panther/config/core/models/observer.py
+++ b/panther/config/core/models/observer.py
@@ -1,17 +1,40 @@
 """Observer configuration models."""
 
+from enum import Enum
 from typing import Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from ..base import BaseConfig
+
+
+class StorageFormat(str, Enum):
+    """Storage data format."""
+
+    JSON = "json"
+    SQLITE = "sqlite"
+    CSV = "csv"
+
+
+class ReportFormat(str, Enum):
+    """Experiment report format."""
+
+    MARKDOWN = "markdown"
+    HTML = "html"
+    JSON = "json"
 
 
 class BaseObserverConfig(BaseConfig):
     """Base configuration for all observers."""
 
     enabled: bool = Field(True, description="Whether this observer is enabled")
-    priority: int = Field(100, description="Observer priority (lower executes first)")
+    priority: int = Field(
+        100,
+        ge=0,
+        le=1000,
+        description="Observer priority (lower executes first)",
+        examples=[0, 50, 100, 200],
+    )
     auto_register: bool = Field(
         False, description="Whether to automatically register with event manager"
     )
@@ -29,7 +52,9 @@ class LoggerObserverConfig(BaseObserverConfig):
     log_to_console: bool = Field(True, description="Log to console")
     file_rotation: bool = Field(True, description="Enable log file rotation")
     max_file_size: str = Field("10MB", description="Maximum log file size")
-    backup_count: int = Field(5, description="Number of backup files to keep")
+    backup_count: int = Field(
+        5, ge=0, le=100, description="Number of backup files to keep"
+    )
     include_data: bool = Field(True, description="Include data in log events")
     include_event_id: bool = Field(True, description="Include event ID in log messages")
     include_timestamp: bool = Field(
@@ -49,7 +74,13 @@ class MetricsObserverConfig(BaseObserverConfig):
 
     log_level: str = Field("INFO", description="Log level for this observer")
     collect_system_metrics: bool = Field(True, description="Collect system metrics")
-    publish_interval: int = Field(30, description="Metrics publish interval (seconds)")
+    publish_interval: int = Field(
+        30,
+        ge=1,
+        le=3600,
+        description="Metrics publish interval (seconds)",
+        json_schema_extra={"unit": "seconds"},
+    )
     export_format: str = Field("json", description="Export format (json, prometheus)")
     export_path: Optional[str] = Field(None, description="Path to export metrics")
     include_histograms: bool = Field(True, description="Include histogram data")
@@ -60,10 +91,18 @@ class MetricsObserverConfig(BaseObserverConfig):
         True, description="Enable real-time metrics monitoring"
     )
     resource_collection_interval: int = Field(
-        5, description="Resource collection interval (seconds)"
+        5,
+        ge=1,
+        le=3600,
+        description="Resource collection interval (seconds)",
+        json_schema_extra={"unit": "seconds"},
     )
     metric_collection_interval: int = Field(
-        10, description="Metric collection interval (seconds)"
+        10,
+        ge=1,
+        le=3600,
+        description="Metric collection interval (seconds)",
+        json_schema_extra={"unit": "seconds"},
     )
 
 
@@ -73,19 +112,61 @@ class StorageObserverConfig(BaseObserverConfig):
     log_level: str = Field("INFO", description="Log level for this observer")
     storage_path: str = Field("outputs/storage", description="Storage path")
     enable_compression: bool = Field(False, description="Enable data compression")
-    retention_days: int = Field(30, description="Data retention period (days)")
-    storage_format: str = Field("json", description="Storage format")
-    buffer_size: int = Field(1000, description="Event buffer size")
-    flush_interval: int = Field(60, description="Buffer flush interval (seconds)")
+    retention_days: int = Field(
+        30,
+        ge=1,
+        le=365,
+        description="Data retention period (days)",
+        json_schema_extra={"unit": "days"},
+    )
+    storage_format: StorageFormat = Field(
+        StorageFormat.JSON,
+        description="Storage format",
+        examples=["json", "sqlite", "csv"],
+    )
+    buffer_size: int = Field(
+        1000,
+        ge=1,
+        le=100000,
+        description="Event buffer size",
+    )
+    flush_interval: int = Field(
+        60,
+        ge=1,
+        le=86400,
+        description="Buffer flush interval (seconds)",
+        json_schema_extra={"unit": "seconds"},
+    )
     create_indexes: bool = Field(True, description="Create indexes for fast queries")
     auto_backup: bool = Field(True, description="Whether to automatically backup data")
     backup_interval: int = Field(
-        3600, description="Backup interval in seconds (default 1 hour)"
+        3600,
+        ge=60,
+        le=604800,
+        description="Backup interval in seconds (default 1 hour)",
+        json_schema_extra={"unit": "seconds"},
     )
     max_storage_size: Optional[int] = Field(
         None, description="Maximum storage size in bytes"
     )
-    batch_size: int = Field(100, description="Number of events to batch before writing")
+    batch_size: int = Field(
+        100,
+        ge=1,
+        le=10000,
+        description="Number of events to batch before writing",
+    )
+
+    @field_validator("storage_format", mode="before")
+    @classmethod
+    def validate_storage_format(cls, v):
+        """Convert string to StorageFormat enum."""
+        if isinstance(v, str):
+            try:
+                return StorageFormat(v.lower())
+            except ValueError:
+                valid = [e.value for e in StorageFormat]
+                raise ValueError(f"Invalid storage format '{v}'. Valid: {valid}")
+        return v
 
 
 class ExperimentObserverConfig(BaseObserverConfig):
@@ -95,7 +176,24 @@ class ExperimentObserverConfig(BaseObserverConfig):
     track_timing: bool = Field(True, description="Track timing information")
     track_steps: bool = Field(True, description="Track experiment steps")
     generate_report: bool = Field(True, description="Generate experiment report")
-    report_format: str = Field("markdown", description="Report format (markdown, html)")
+    report_format: ReportFormat = Field(
+        ReportFormat.MARKDOWN,
+        description="Report format",
+        examples=["markdown", "html", "json"],
+    )
+
+    @field_validator("report_format", mode="before")
+    @classmethod
+    def validate_report_format(cls, v):
+        """Convert string to ReportFormat enum."""
+        if isinstance(v, str):
+            try:
+                return ReportFormat(v.lower())
+            except ValueError:
+                valid = [e.value for e in ReportFormat]
+                raise ValueError(f"Invalid report format '{v}'. Valid: {valid}")
+        return v
+
     include_graphs: bool = Field(True, description="Include graphs in report")
     capture_screenshots: bool = Field(
         False, description="Capture screenshots during execution"

--- a/panther/config/core/models/plugin.py
+++ b/panther/config/core/models/plugin.py
@@ -12,11 +12,10 @@ class ProtocolPluginConfig(BaseConfig):
 
     enabled: bool = Field(True, description="Whether the plugin is enabled")
     version: Optional[str] = Field(None, description="Plugin version")
-    priority: int = Field(100, description="Plugin execution priority")
-    protocol_version: str = Field(..., description="Protocol version")
-    default_port: int = Field(..., description="Default port number")
-    supports_tls: bool = Field(True, description="Whether protocol supports TLS")
-
-    def get_plugin_type(self) -> str:
-        """Return protocol plugin type."""
-        return "protocol"
+    priority: int = Field(
+        100,
+        ge=0,
+        le=1000,
+        description="Plugin execution priority",
+        examples=[0, 50, 100, 200],
+    )

--- a/panther/config/core/models/protocol.py
+++ b/panther/config/core/models/protocol.py
@@ -1,11 +1,50 @@
 """Protocol configuration models."""
 
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from ..base import BaseConfig
+
+
+class HttpMethod(str, Enum):
+    """HTTP request method."""
+
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+    PATCH = "PATCH"
+    HEAD = "HEAD"
+    OPTIONS = "OPTIONS"
+
+
+class HttpVersion(str, Enum):
+    """HTTP version."""
+
+    HTTP_1_0 = "1.0"
+    HTTP_1_1 = "1.1"
+    HTTP_2 = "2"
+    HTTP_3 = "3"
+
+
+class TlsVerifyMode(str, Enum):
+    """TLS certificate verification mode."""
+
+    NONE = "none"
+    OPTIONAL = "optional"
+    REQUIRED = "required"
+
+
+class CongestionControl(str, Enum):
+    """Congestion control algorithm."""
+
+    RENO = "reno"
+    CUBIC = "cubic"
+    BBR = "bbr"
+    BBR2 = "bbr2"
 
 
 class BaseProtocolConfig(BaseConfig, ABC):
@@ -38,23 +77,27 @@ class ClientServerProtocolConfig(BaseProtocolConfig):
 
     # QUIC-specific parameters
     quic_version: Optional[str] = Field(None, description="QUIC version string")
-    initial_max_data: Optional[int] = Field(10485760, description="Initial max data")
+    initial_max_data: Optional[int] = Field(
+        10485760, ge=0, description="Initial max data"
+    )
     initial_max_stream_data_bidi_local: Optional[int] = Field(
-        1048576, description="Initial max stream data bidi local"
+        1048576, ge=0, description="Initial max stream data bidi local"
     )
     initial_max_stream_data_bidi_remote: Optional[int] = Field(
-        1048576, description="Initial max stream data bidi remote"
+        1048576, ge=0, description="Initial max stream data bidi remote"
     )
     initial_max_stream_data_uni: Optional[int] = Field(
-        1048576, description="Initial max stream data uni"
+        1048576, ge=0, description="Initial max stream data uni"
     )
     initial_max_streams_bidi: Optional[int] = Field(
-        100, description="Initial max streams bidi"
+        100, ge=0, description="Initial max streams bidi"
     )
     initial_max_streams_uni: Optional[int] = Field(
-        100, description="Initial max streams uni"
+        100, ge=0, description="Initial max streams uni"
     )
-    max_idle_timeout: Optional[int] = Field(30000, description="Max idle timeout in ms")
+    max_idle_timeout: Optional[int] = Field(
+        30000, ge=0, description="Max idle timeout in ms"
+    )
 
     # TLS parameters
     alpn_protocols: List[str] = Field(
@@ -64,32 +107,102 @@ class ClientServerProtocolConfig(BaseProtocolConfig):
     key_file: Optional[str] = Field(None, description="TLS key file path")
     cert_file: Optional[str] = Field(None, description="TLS certificate file path")
     ca_file: Optional[str] = Field(None, description="CA certificate file path")
-    verify_mode: Optional[str] = Field(None, description="TLS verify mode")
+    verify_mode: Optional[TlsVerifyMode] = Field(
+        None,
+        description="TLS verify mode",
+        examples=["none", "optional", "required"],
+    )
 
     # HTTP-specific parameters
-    http_version: Optional[str] = Field(None, description="HTTP version (1.1, 2, 3)")
+    http_version: Optional[HttpVersion] = Field(
+        None,
+        description="HTTP version",
+        examples=["1.0", "1.1", "2", "3"],
+    )
     request_headers: Dict[str, str] = Field(
         default_factory=dict, description="HTTP request headers"
     )
     response_headers: Dict[str, str] = Field(
         default_factory=dict, description="HTTP response headers"
     )
-    body_size: Optional[int] = Field(None, description="HTTP body size")
-    method: Optional[str] = Field("GET", description="HTTP method")
+    body_size: Optional[int] = Field(None, ge=0, description="HTTP body size")
+    method: Optional[HttpMethod] = Field(
+        HttpMethod.GET,
+        description="HTTP method",
+        examples=["GET", "POST", "PUT", "DELETE"],
+    )
     path: Optional[str] = Field("/", description="HTTP path")
 
     # Connection parameters
     connection_timeout: Optional[int] = Field(
-        10000, description="Connection timeout in ms"
+        10000, ge=0, description="Connection timeout in ms"
     )
     keep_alive: Optional[bool] = Field(True, description="Enable keep-alive")
-    retry_count: Optional[int] = Field(3, description="Connection retry count")
+    retry_count: Optional[int] = Field(
+        3, ge=0, le=100, description="Connection retry count"
+    )
 
     # Performance parameters
-    congestion_control: Optional[str] = Field(
-        None, description="Congestion control algorithm"
+    congestion_control: Optional[CongestionControl] = Field(
+        None,
+        description="Congestion control algorithm",
+        examples=["reno", "cubic", "bbr", "bbr2"],
     )
     pacing: Optional[bool] = Field(True, description="Enable pacing")
+
+    @field_validator("method", mode="before")
+    @classmethod
+    def validate_method(cls, v):
+        """Convert string to HttpMethod enum."""
+        if isinstance(v, str):
+            try:
+                return HttpMethod(v.upper())
+            except ValueError:
+                valid = [e.value for e in HttpMethod]
+                raise ValueError(f"Invalid HTTP method '{v}'. Valid: {valid}")
+        return v
+
+    @field_validator("http_version", mode="before")
+    @classmethod
+    def validate_http_version(cls, v):
+        """Convert string to HttpVersion enum."""
+        if v is None:
+            return v
+        if isinstance(v, str):
+            try:
+                return HttpVersion(v)
+            except ValueError:
+                valid = [e.value for e in HttpVersion]
+                raise ValueError(f"Invalid HTTP version '{v}'. Valid: {valid}")
+        return v
+
+    @field_validator("verify_mode", mode="before")
+    @classmethod
+    def validate_verify_mode(cls, v):
+        """Convert string to TlsVerifyMode enum."""
+        if v is None:
+            return v
+        if isinstance(v, str):
+            try:
+                return TlsVerifyMode(v.lower())
+            except ValueError:
+                valid = [e.value for e in TlsVerifyMode]
+                raise ValueError(f"Invalid TLS verify mode '{v}'. Valid: {valid}")
+        return v
+
+    @field_validator("congestion_control", mode="before")
+    @classmethod
+    def validate_congestion_control(cls, v):
+        """Convert string to CongestionControl enum."""
+        if v is None:
+            return v
+        if isinstance(v, str):
+            try:
+                return CongestionControl(v.lower())
+            except ValueError:
+                valid = [e.value for e in CongestionControl]
+                raise ValueError(f"Invalid congestion control '{v}'. Valid: {valid}")
+        return v
 
     def get_default_parameters(self) -> Dict[str, Any]:
         """Get default parameters based on protocol."""
@@ -165,12 +278,18 @@ class PeerToPeerProtocolConfig(BaseProtocolConfig):
     # Discovery parameters
     enable_mdns: bool = Field(True, description="Enable mDNS discovery")
     enable_dht: bool = Field(True, description="Enable DHT")
-    discovery_interval: int = Field(30, description="Discovery interval in seconds")
+    discovery_interval: int = Field(
+        30, ge=1, le=86400, description="Discovery interval in seconds"
+    )
 
     # Connection parameters
-    max_peers: int = Field(50, description="Maximum number of peers")
-    connection_timeout: int = Field(30, description="Connection timeout in seconds")
-    ping_interval: int = Field(60, description="Ping interval in seconds")
+    max_peers: int = Field(50, ge=1, le=10000, description="Maximum number of peers")
+    connection_timeout: int = Field(
+        30, ge=1, le=3600, description="Connection timeout in seconds"
+    )
+    ping_interval: int = Field(
+        60, ge=1, le=86400, description="Ping interval in seconds"
+    )
 
     # Security parameters
     enable_encryption: bool = Field(True, description="Enable encryption")

--- a/panther/config/core/models/service.py
+++ b/panther/config/core/models/service.py
@@ -40,14 +40,52 @@ class ProtocolRole(str, Enum):
     PEER = "peer"
 
 
+class RestartPolicy(str, Enum):
+    """Docker restart policy."""
+
+    NO = "no"
+    ALWAYS = "always"
+    ON_FAILURE = "on-failure"
+    UNLESS_STOPPED = "unless-stopped"
+
+
 class NetworkConfig(BaseConfig):
     """Network configuration for services."""
 
-    interface: str = Field("eth0", description="Network interface")
-    port: int = Field(4443, description="Network port")
-    host: str = Field("localhost", description="Host address")
-    bind_address: Optional[str] = Field(None, description="Bind address")
-    mtu: Optional[int] = Field(None, description="Maximum transmission unit")
+    interface: str = Field(
+        "eth0",
+        description="Network interface",
+        examples=["eth0", "lo", "br0"],
+        json_schema_extra={"category": "network"},
+    )
+    port: int = Field(
+        4443,
+        ge=1,
+        le=65535,
+        description="Network port",
+        examples=[4443, 8080, 443],
+        json_schema_extra={"widget_type": "port", "category": "network"},
+    )
+    host: str = Field(
+        "localhost",
+        description="Host address",
+        examples=["localhost", "0.0.0.0", "192.168.1.1"],
+        json_schema_extra={"category": "network"},
+    )
+    bind_address: Optional[str] = Field(
+        None,
+        description="Bind address",
+        examples=["0.0.0.0", "127.0.0.1"],
+        json_schema_extra={"category": "network"},
+    )
+    mtu: Optional[int] = Field(
+        None,
+        ge=68,
+        le=65535,
+        description="Maximum transmission unit",
+        examples=[1500, 9000],
+        json_schema_extra={"category": "network", "advanced": True},
+    )
 
     @field_validator("port", mode="before")
     @classmethod
@@ -70,9 +108,20 @@ class NetworkConfig(BaseConfig):
 
 class ProtocolConfig(BaseConfig):
     ## TODO check which verson is used in the protocol config
-    """Protocol configuration."""
+    """Protocol configuration.
 
-    name: str = Field(..., description="Protocol name (e.g., quic, http)")
+    Note: The ``version`` field here is the *protocol specification* version
+    (e.g., ``rfc9000``, ``draft-29``), distinct from ``ImplementationConfig.version``
+    which tracks the *software implementation* version.
+    """
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        description="Protocol name",
+        examples=["quic", "http", "minip"],
+        json_schema_extra={"category": "protocol"},
+    )
     version: Optional[str] = Field(None, description="Protocol version")
     role: ProtocolRole = Field(..., description="Protocol role")
     target: Optional[str] = Field(None, description="Target service name (for clients)")
@@ -131,7 +180,13 @@ class ProtocolConfig(BaseConfig):
 class ImplementationConfig(BaseConfig):
     """Implementation configuration."""
 
-    name: str = Field(..., description="Implementation name")
+    name: str = Field(
+        ...,
+        min_length=1,
+        description="Implementation name",
+        examples=["picoquic", "aioquic", "quiche"],
+        json_schema_extra={"category": "implementation"},
+    )
     type: ImplementationType = Field(..., description="Implementation type")
     version: Optional[str] = Field(None, description="Implementation version")
     version_config: Optional[Dict[str, Any]] = Field(
@@ -160,33 +215,81 @@ class ServiceConfig(BaseConfig):
     VERSION_CLASS: ClassVar[Optional[type]] = None
 
     implementation: ImplementationConfig = Field(
-        ..., description="Implementation configuration"
+        ...,
+        description="Implementation configuration",
+        json_schema_extra={"category": "general"},
     )
-    protocol: ProtocolConfig = Field(..., description="Protocol configuration")
-    network: Optional[NetworkConfig] = Field(None, description="Network configuration")
+    protocol: ProtocolConfig = Field(
+        ...,
+        description="Protocol configuration",
+        json_schema_extra={"category": "general"},
+    )
+    network: Optional[NetworkConfig] = Field(
+        None,
+        description="Network configuration",
+        json_schema_extra={"category": "network"},
+    )
     environment: Dict[str, str] = Field(
-        default_factory=dict, description="Environment variables"
+        default_factory=dict,
+        description="Environment variables injected into the container",
+        examples=[{"RUST_LOG": "debug"}],
+        json_schema_extra={"widget_type": "key_value", "category": "docker"},
     )
-    timeout: int = Field(60, description="Service timeout in seconds")
+    timeout: int = Field(
+        60,
+        ge=1,
+        le=86400,
+        description="Service timeout in seconds",
+        examples=[30, 60, 120, 300],
+        json_schema_extra={
+            "widget_type": "spinner",
+            "category": "general",
+            "unit": "seconds",
+        },
+    )
     ports: List[str] = Field(
-        default_factory=list, description="Port mappings (host:container)"
+        default_factory=list,
+        description="Port mappings (host:container)",
+        examples=["4443:4443", "8080:80"],
+        json_schema_extra={"category": "network"},
     )
-    volumes: List[str] = Field(default_factory=list, description="Volume mounts")
+    volumes: List[str] = Field(
+        default_factory=list,
+        description="Volume mounts",
+        examples=["./data:/app/data"],
+        json_schema_extra={"category": "docker"},
+    )
     generate_new_certificates: bool = Field(
-        False, description="Generate new certificates"
+        False,
+        description="Generate new TLS certificates for this service",
+        json_schema_extra={"category": "security"},
     )
     command_override: Optional[str] = Field(
-        None, description="Override service command"
+        None,
+        description="Override service command",
+        json_schema_extra={"category": "docker", "advanced": True},
     )
-    working_directory: Optional[str] = Field(None, description="Working directory")
+    working_directory: Optional[str] = Field(
+        None,
+        description="Working directory inside the container",
+        json_schema_extra={"category": "docker", "advanced": True},
+    )
     depends_on: List[str] = Field(
-        default_factory=list, description="Service dependencies"
+        default_factory=list,
+        description="Service dependencies (started before this service)",
+        json_schema_extra={"category": "general"},
     )
-    restart_policy: str = Field("no", description="Restart policy")
+    restart_policy: RestartPolicy = Field(
+        RestartPolicy.NO,
+        description="Docker restart policy",
+        examples=["no", "always", "on-failure"],
+        json_schema_extra={"category": "docker"},
+    )
 
     docker: Optional[ServiceDockerOverrideConfig] = Field(
         None,
         description="Per-service Docker build overrides (inherits from global if absent)",
+        json_schema_extra={"category": "docker", "advanced": True},
     )
 
     # Service build/docker fields
@@ -304,6 +407,18 @@ class ServiceConfig(BaseConfig):
                 ) from e
         return cls()
 
+    @field_validator("restart_policy", mode="before")
+    @classmethod
+    def validate_restart_policy(cls, v):
+        """Convert string to RestartPolicy enum."""
+        if isinstance(v, str):
+            try:
+                return RestartPolicy(v.lower())
+            except ValueError:
+                valid = [e.value for e in RestartPolicy]
+                raise ValueError(f"Invalid restart policy '{v}'. Valid: {valid}")
+        return v
+
     @field_validator("timeout", mode="before")
     @classmethod
     def validate_timeout(cls, v):
@@ -390,10 +505,18 @@ class ServiceConfig(BaseConfig):
         Returns:
             Docker Compose service dictionary
         """
+        # BaseConfig has use_enum_values=True, so restart_policy is already
+        # stored as a string value. Handle both cases defensively.
+        restart_val = (
+            self.restart_policy.value
+            if isinstance(self.restart_policy, RestartPolicy)
+            else self.restart_policy
+        )
+
         service = {
             "image": f"panther/{self.implementation.name}:latest",
             "environment": self.environment.copy(),
-            "restart": self.restart_policy,
+            "restart": restart_val,
         }
 
         if self.ports:

--- a/panther/config/core/models/service.py
+++ b/panther/config/core/models/service.py
@@ -53,7 +53,7 @@ class NetworkConfig(BaseConfig):
     @classmethod
     def validate_port(cls, v):
         """Convert string/float to integer for port."""
-        from ..components.universal_validators import validate_integer_field
+        from ..components.field_coercion import validate_integer_field
 
         return validate_integer_field(v, "port")
 
@@ -63,7 +63,7 @@ class NetworkConfig(BaseConfig):
         """Convert string/float to integer for MTU."""
         if v is None:
             return v
-        from ..components.universal_validators import validate_integer_field
+        from ..components.field_coercion import validate_integer_field
 
         return validate_integer_field(v, "mtu")
 
@@ -308,7 +308,7 @@ class ServiceConfig(BaseConfig):
     @classmethod
     def validate_timeout(cls, v):
         """Convert string/float to integer and validate timeout is positive."""
-        from ..components.universal_validators import validate_integer_field
+        from ..components.field_coercion import validate_integer_field
 
         # First convert to integer
         timeout_val = validate_integer_field(v, "timeout")
@@ -333,7 +333,7 @@ class ServiceConfig(BaseConfig):
 
             try:
                 # Use universal validator to handle decimal strings
-                from ..components.universal_validators import validate_integer_field
+                from ..components.field_coercion import validate_integer_field
 
                 host_port = validate_integer_field(
                     parts[0], f"host_port in {port_mapping}"

--- a/panther/config/core/validators/__init__.py
+++ b/panther/config/core/validators/__init__.py
@@ -21,49 +21,49 @@ __all__ = [
 def __getattr__(name):  # pylint: disable=invalid-name
     """Lazy import implementation to avoid circular imports."""
     if name == "create_enum_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             create_enum_validator,
         )
 
         return create_enum_validator
     elif name == "create_time_string_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             create_time_string_validator,
         )
 
         return create_time_string_validator
     elif name == "create_case_insensitive_string_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             create_case_insensitive_string_validator,
         )
 
         return create_case_insensitive_string_validator
     elif name == "create_type_conversion_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             create_type_conversion_validator,
         )
 
         return create_type_conversion_validator
     elif name == "protocol_role_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             protocol_role_validator,
         )
 
         return protocol_role_validator
     elif name == "implementation_type_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             implementation_type_validator,
         )
 
         return implementation_type_validator
     elif name == "logging_level_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             logging_level_validator,
         )
 
         return logging_level_validator
     elif name == "shadow_time_validator":
-        from .universal_validators import (  # pylint: disable=import-outside-toplevel
+        from .pydantic_factories import (  # pylint: disable=import-outside-toplevel
             shadow_time_validator,
         )
 

--- a/panther/config/core/validators/pydantic_factories.py
+++ b/panther/config/core/validators/pydantic_factories.py
@@ -1,44 +1,23 @@
 """Pydantic validator factory functions for PANTHER configuration models.
 
 This module provides *factory functions* that return validator callables compatible
-with Pydantic's ``@field_validator`` (v2) and ``@validator`` (v1) decorators. Use
-these when you need to attach reusable validation logic to Pydantic model fields.
+with Pydantic's ``@field_validator`` (v2) decorators. Use these when you need to
+attach reusable validation logic to Pydantic model fields.
 
-Contrast with ``panther.config.core.components.universal_validators``, which provides
-standalone validation functions for imperative use outside of Pydantic models
-(e.g., ``validate_integer_field(value, "port")``).
+Contrast with ``panther.config.core.components.field_coercion``, which provides
+standalone coercion functions for imperative use outside of Pydantic models.
 
-Factory functions (``create_*``)
-    Return a ``Callable[[cls, Any], T]`` suitable for assignment to a Pydantic
-    field validator. Each factory accepts configuration parameters (enum class,
-    time units, valid values, etc.) and returns a closure that performs the
-    actual validation.
+Factory functions (return callables):
+- ``create_enum_validator`` — Case-insensitive enum coercion
+- ``create_time_string_validator`` — Time string normalization (e.g., "30s", "5m")
+- ``create_case_insensitive_string_validator`` — Case-insensitive string matching
+- ``create_type_conversion_validator`` — Generic type conversion
 
-Pre-configured validators
-    Convenience functions (``protocol_role_validator``, ``implementation_type_validator``,
-    ``logging_level_validator``, ``shadow_time_validator``) that wrap the factory
-    functions with PANTHER-specific enum classes for immediate use.
-
-Typical usage::
-
-    from pydantic import BaseModel, field_validator
-    from panther.config.core.validators.universal_validators import (
-        create_enum_validator,
-        create_time_string_validator,
-        protocol_role_validator,
-    )
-    from panther.config.core.models.service import ProtocolRole
-
-    class ServiceProtocolConfig(BaseModel):
-        role: ProtocolRole
-        stop_time: str = "30s"
-
-        _validate_role = field_validator("role", mode="before")(
-            protocol_role_validator
-        )
-        _validate_stop_time = field_validator("stop_time", mode="before")(
-            create_time_string_validator(default_unit="s")
-        )
+Pre-configured validators (use directly with ``@field_validator``):
+- ``protocol_role_validator`` — Validates ProtocolRole enum
+- ``implementation_type_validator`` — Validates ImplementationType enum
+- ``logging_level_validator`` — Validates LoggingLevel enum
+- ``shadow_time_validator`` — Validates Shadow NS time format
 """
 
 import logging

--- a/panther/plugins/core/plugin_loader_utils.py
+++ b/panther/plugins/core/plugin_loader_utils.py
@@ -27,6 +27,19 @@ class PluginManagerUtils(LoggerMixin):
     """
 
     @classmethod
+    def _compute_package_path(cls, file_path: Path) -> Optional[str]:
+        """Compute dotted package path by walking up from file_path's parent."""
+        parts = []
+        current = file_path.parent
+        while (current / "__init__.py").exists():
+            parts.append(current.name)
+            current = current.parent
+        if parts:
+            parts.reverse()
+            return ".".join(parts)
+        return None
+
+    @classmethod
     def load_module_from_file(
         cls, file_path: Path, module_name: Optional[str] = None
     ) -> Any:
@@ -49,29 +62,49 @@ class PluginManagerUtils(LoggerMixin):
         if module_name is None:
             module_name = file_path.stem
 
-        # If module_name has no dots (bare name), derive full package path.
-        # This enables relative imports within the panther package, matching
-        # the logic in plugin_discovery._import_module_file().
-        if "." not in module_name:
-            try:
-                panther_root = Path(__file__).parent.parent.parent  # -> panther/
-                relative_path = file_path.relative_to(panther_root)
-                module_name = "panther." + str(relative_path).replace("/", ".").replace(
-                    "\\", "."
-                ).replace(".py", "")
-            except ValueError:
-                pass  # File outside panther package, keep bare name
+        # Compute fully-qualified module name for proper relative import support
+        package_path = cls._compute_package_path(file_path)
+        if package_path:
+            fq_module_name = f"{package_path}.{file_path.stem}"
+        else:
+            fq_module_name = module_name
 
         # Return cached module if already loaded (avoids re-execution)
-        if module_name in sys.modules:
-            return sys.modules[module_name]
+        if fq_module_name in sys.modules:
+            return sys.modules[fq_module_name]
 
-        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        spec = importlib.util.spec_from_file_location(fq_module_name, file_path)
         if spec is None or spec.loader is None:
             raise ImportError(f"Could not find module at {file_path}")
 
         module = importlib.util.module_from_spec(spec)
+
+        # Set __package__ to enable relative imports within plugin packages
+        if package_path:
+            module.__package__ = package_path
+            # Ensure parent package is in sys.modules for import resolution
+            if package_path not in sys.modules:
+                parent_init = file_path.parent / "__init__.py"
+                if parent_init.exists():
+                    parent_spec = importlib.util.spec_from_file_location(
+                        package_path,
+                        parent_init,
+                        submodule_search_locations=[str(file_path.parent)],
+                    )
+                    if parent_spec and parent_spec.loader:
+                        parent_mod = importlib.util.module_from_spec(parent_spec)
+                        parent_mod.__package__ = package_path
+                        sys.modules[package_path] = parent_mod
+                        try:
+                            parent_spec.loader.exec_module(parent_mod)
+                        except Exception:
+                            pass  # Stub entry is sufficient for relative imports
+
+        # Register under both simple and qualified names for compatibility
         sys.modules[module_name] = module
+        if fq_module_name != module_name:
+            sys.modules[fq_module_name] = module
+
         spec.loader.exec_module(module)
 
         return module

--- a/panther/plugins/environments/execution_environment/gdb/config_schema.py
+++ b/panther/plugins/environments/execution_environment/gdb/config_schema.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from pydantic import Field, validator
 
-from panther.config.core.components.universal_validators import validate_integer_field
+from panther.config.core.components.field_coercion import validate_integer_field
 from panther.config.core.models.environment import ExecutionEnvironmentConfig
 
 

--- a/panther/plugins/environments/execution_environment/gperf_heap/config_schema.py
+++ b/panther/plugins/environments/execution_environment/gperf_heap/config_schema.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from pydantic import Field, validator
 
-from panther.config.core.components.universal_validators import validate_integer_field
+from panther.config.core.components.field_coercion import validate_integer_field
 from panther.config.core.models.environment import ExecutionEnvironmentConfig
 
 

--- a/panther/plugins/environments/execution_environment/iterations/config_schema.py
+++ b/panther/plugins/environments/execution_environment/iterations/config_schema.py
@@ -4,7 +4,7 @@ from typing import List
 
 from pydantic import Field, validator
 
-from panther.config.core.components.universal_validators import validate_integer_field
+from panther.config.core.components.field_coercion import validate_integer_field
 from panther.config.core.models.environment import ExecutionEnvironmentConfig
 
 

--- a/panther/plugins/environments/execution_environment/memcheck/config_schema.py
+++ b/panther/plugins/environments/execution_environment/memcheck/config_schema.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from pydantic import Field, validator
 
-from panther.config.core.components.universal_validators import validate_integer_field
+from panther.config.core.components.field_coercion import validate_integer_field
 from panther.config.core.models.environment import ExecutionEnvironmentConfig
 
 

--- a/panther/plugins/environments/execution_environment/strace/config_schema.py
+++ b/panther/plugins/environments/execution_environment/strace/config_schema.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from pydantic import Field, validator
 
-from panther.config.core.components.universal_validators import validate_integer_field
+from panther.config.core.components.field_coercion import validate_integer_field
 from panther.config.core.models.environment import ExecutionEnvironmentConfig
 
 

--- a/tests/unit/test_config/test_compatibility_validator.py
+++ b/tests/unit/test_config/test_compatibility_validator.py
@@ -1,0 +1,32 @@
+"""Tests for CompatibilityValidator after cleanup."""
+
+from panther.config.core.components.validators import CompatibilityValidator
+
+
+class TestCompatibilityValidatorCleaned:
+    def test_no_warnings_on_valid_config(self):
+        """No legacy checks remain — any valid dict should pass clean."""
+        validator = CompatibilityValidator()
+        result = validator.validate({"some_field": "value"})
+        assert result.is_valid
+        assert len(result.warnings) == 0
+
+    def test_empty_config(self):
+        validator = CompatibilityValidator()
+        result = validator.validate({})
+        assert result.is_valid
+        assert len(result.warnings) == 0
+
+    def test_formerly_deprecated_fields_no_warnings(self):
+        """Fields that were formerly deprecated should no longer trigger warnings."""
+        validator = CompatibilityValidator()
+        result = validator.validate({"use_docker": True, "log_level": "INFO"})
+        assert result.is_valid
+        assert len(result.warnings) == 0
+
+    def test_legacy_config_key_no_warnings(self):
+        """Legacy nested 'config' key should no longer trigger warnings."""
+        validator = CompatibilityValidator()
+        result = validator.validate({"config": {"nested": "value"}})
+        assert result.is_valid
+        assert len(result.warnings) == 0

--- a/tests/unit/test_config/test_env_plugin_constraints.py
+++ b/tests/unit/test_config/test_env_plugin_constraints.py
@@ -1,0 +1,30 @@
+"""Tests for environment and plugin config constraints."""
+
+import pytest
+
+from panther.config.core.models.environment import EnvironmentConfig
+from panther.config.core.models.plugin import ProtocolPluginConfig
+
+
+class TestEnvironmentConstraints:
+    def test_monitoring_interval_zero(self):
+        with pytest.raises(Exception):
+            EnvironmentConfig(type="docker_compose", monitoring_interval_seconds=0)
+
+    def test_failure_threshold_zero(self):
+        with pytest.raises(Exception):
+            EnvironmentConfig(type="docker_compose", failure_threshold_count=0)
+
+
+class TestPluginConstraints:
+    def test_port_too_high(self):
+        with pytest.raises(Exception):
+            ProtocolPluginConfig(protocol_version="1.0", default_port=70000)
+
+    def test_port_zero(self):
+        with pytest.raises(Exception):
+            ProtocolPluginConfig(protocol_version="1.0", default_port=0)
+
+    def test_priority_negative(self):
+        with pytest.raises(Exception):
+            ProtocolPluginConfig(protocol_version="1.0", default_port=443, priority=-1)

--- a/tests/unit/test_config/test_env_plugin_constraints.py
+++ b/tests/unit/test_config/test_env_plugin_constraints.py
@@ -17,14 +17,14 @@ class TestEnvironmentConstraints:
 
 
 class TestPluginConstraints:
-    def test_port_too_high(self):
-        with pytest.raises(Exception):
-            ProtocolPluginConfig(protocol_version="1.0", default_port=70000)
-
-    def test_port_zero(self):
-        with pytest.raises(Exception):
-            ProtocolPluginConfig(protocol_version="1.0", default_port=0)
-
     def test_priority_negative(self):
         with pytest.raises(Exception):
-            ProtocolPluginConfig(protocol_version="1.0", default_port=443, priority=-1)
+            ProtocolPluginConfig(priority=-1)
+
+    def test_priority_too_high(self):
+        with pytest.raises(Exception):
+            ProtocolPluginConfig(priority=1001)
+
+    def test_priority_valid(self):
+        config = ProtocolPluginConfig(priority=50)
+        assert config.priority == 50

--- a/tests/unit/test_config/test_experiment_constraints.py
+++ b/tests/unit/test_config/test_experiment_constraints.py
@@ -1,0 +1,52 @@
+"""Tests for experiment config constraints."""
+
+import pytest
+
+from panther.config.core.models.experiment import StepsConfig, TestConfig
+
+
+class TestExperimentConstraints:
+    def test_wait_too_high(self):
+        with pytest.raises(Exception):
+            StepsConfig(wait=100000)
+
+    def test_iterations_too_high(self):
+        with pytest.raises(Exception):
+            TestConfig(
+                name="test",
+                network_environment={"type": "docker_compose"},
+                services={
+                    "s": {
+                        "implementation": {"name": "test", "type": "iut"},
+                        "protocol": {"name": "quic", "role": "server"},
+                    }
+                },
+                iterations=1001,
+            )
+
+    def test_name_empty(self):
+        with pytest.raises(Exception):
+            TestConfig(
+                name="",
+                network_environment={"type": "docker_compose"},
+                services={
+                    "s": {
+                        "implementation": {"name": "test", "type": "iut"},
+                        "protocol": {"name": "quic", "role": "server"},
+                    }
+                },
+            )
+
+    def test_timeout_too_high(self):
+        with pytest.raises(Exception):
+            TestConfig(
+                name="test",
+                network_environment={"type": "docker_compose"},
+                services={
+                    "s": {
+                        "implementation": {"name": "test", "type": "iut"},
+                        "protocol": {"name": "quic", "role": "server"},
+                    }
+                },
+                timeout=100000,
+            )

--- a/tests/unit/test_config/test_global_config_enums.py
+++ b/tests/unit/test_config/test_global_config_enums.py
@@ -1,0 +1,75 @@
+"""Tests for global_config enums and constraints."""
+
+import pytest
+
+from panther.config.core.models.global_config import (
+    DockerConfig,
+    DockerNetworkMode,
+    DockerUserMappingConfig,
+    ExportFormat,
+    FastFailConfig,
+    FeatureLogLevelsConfig,
+    LoggingLevel,
+    MetricsConfig,
+    ProgressConfig,
+)
+
+
+class TestDockerNetworkModeEnum:
+    def test_valid_values(self):
+        for val in ["bridge", "host", "none", "overlay"]:
+            assert DockerNetworkMode(val).value == val
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            DockerNetworkMode("invalid")
+
+    def test_docker_config_accepts_string(self):
+        dc = DockerConfig(network_mode="host")
+        assert dc.network_mode == DockerNetworkMode.HOST
+
+
+class TestExportFormatEnum:
+    def test_valid_values(self):
+        for val in ["json", "csv", "prometheus"]:
+            assert ExportFormat(val).value == val
+
+    def test_metrics_config_accepts_string(self):
+        mc = MetricsConfig(export_format="prometheus")
+        assert mc.export_format == ExportFormat.PROMETHEUS
+
+
+class TestFeatureLogLevelsUsesLoggingLevel:
+    def test_accepts_valid_level(self):
+        flc = FeatureLogLevelsConfig(docker_build="DEBUG")
+        assert flc.docker_build == LoggingLevel.DEBUG
+
+    def test_rejects_invalid_level(self):
+        with pytest.raises(Exception):
+            FeatureLogLevelsConfig(docker_build="INVALID")
+
+
+class TestGlobalConfigConstraints:
+    def test_uid_too_high(self):
+        with pytest.raises(Exception):
+            DockerUserMappingConfig(custom_uid=70000)
+
+    def test_uid_negative(self):
+        with pytest.raises(Exception):
+            DockerUserMappingConfig(custom_uid=-1)
+
+    def test_update_interval_too_low(self):
+        with pytest.raises(Exception):
+            ProgressConfig(update_interval=0.001)
+
+    def test_cascade_threshold_zero(self):
+        with pytest.raises(Exception):
+            FastFailConfig(timeout_cascade_threshold=0)
+
+    def test_publish_interval_zero(self):
+        with pytest.raises(Exception):
+            MetricsConfig(publish_interval=0)
+
+    def test_retention_too_high(self):
+        with pytest.raises(Exception):
+            MetricsConfig(retention_days=400)

--- a/tests/unit/test_config/test_json_schema_extra.py
+++ b/tests/unit/test_config/test_json_schema_extra.py
@@ -1,0 +1,42 @@
+"""Verify json_schema_extra metadata appears in model field definitions."""
+
+from panther.config.core.models.service import ServiceConfig
+
+
+class TestJsonSchemaExtra:
+    def test_service_timeout_has_widget_type(self):
+        field = ServiceConfig.model_fields["timeout"]
+        extra = field.json_schema_extra
+        assert extra is not None
+        assert extra["widget_type"] == "spinner"
+
+    def test_service_timeout_has_unit(self):
+        field = ServiceConfig.model_fields["timeout"]
+        extra = field.json_schema_extra
+        assert extra is not None
+        assert extra["unit"] == "seconds"
+
+    def test_service_timeout_has_examples(self):
+        field = ServiceConfig.model_fields["timeout"]
+        metadata = field.metadata
+        # In Pydantic v2, examples are stored in field metadata or json_schema_extra
+        examples = (
+            field.json_schema_extra.get("examples") if field.json_schema_extra else None
+        )
+        if examples is None:
+            # Check if examples are in the field definition itself
+            assert hasattr(field, "examples") or any(
+                hasattr(m, "examples") for m in metadata
+            ), "Field 'timeout' should have examples"
+
+    def test_all_fields_have_descriptions(self):
+        """Every field in ServiceConfig should have a description."""
+        for field_name, field_info in ServiceConfig.model_fields.items():
+            # Skip internal/excluded fields
+            if field_name.startswith("_") or field_name == "omega_config":
+                continue
+            if field_info.exclude:
+                continue
+            assert (
+                field_info.description is not None
+            ), f"Field '{field_name}' missing description"

--- a/tests/unit/test_config/test_observer_config.py
+++ b/tests/unit/test_config/test_observer_config.py
@@ -1,0 +1,63 @@
+"""Tests for observer config enums and constraints."""
+
+import pytest
+
+from panther.config.core.models.observer import (
+    BaseObserverConfig,
+    ExperimentObserverConfig,
+    LoggerObserverConfig,
+    MetricsObserverConfig,
+    ReportFormat,
+    StorageFormat,
+    StorageObserverConfig,
+)
+
+
+class TestStorageFormatEnum:
+    def test_valid_values(self):
+        for val in ["json", "sqlite", "csv"]:
+            assert StorageFormat(val).value == val
+
+    def test_storage_config_accepts_string(self):
+        sc = StorageObserverConfig(storage_format="sqlite")
+        assert sc.storage_format == StorageFormat.SQLITE
+
+
+class TestReportFormatEnum:
+    def test_valid_values(self):
+        for val in ["markdown", "html", "json"]:
+            assert ReportFormat(val).value == val
+
+    def test_experiment_config_accepts_string(self):
+        ec = ExperimentObserverConfig(report_format="html")
+        assert ec.report_format == ReportFormat.HTML
+
+
+class TestObserverConstraints:
+    def test_priority_negative(self):
+        with pytest.raises(Exception):
+            BaseObserverConfig(priority=-1)
+
+    def test_priority_too_high(self):
+        with pytest.raises(Exception):
+            BaseObserverConfig(priority=1001)
+
+    def test_backup_count_negative(self):
+        with pytest.raises(Exception):
+            LoggerObserverConfig(backup_count=-1)
+
+    def test_buffer_size_zero(self):
+        with pytest.raises(Exception):
+            StorageObserverConfig(buffer_size=0)
+
+    def test_flush_interval_zero(self):
+        with pytest.raises(Exception):
+            StorageObserverConfig(flush_interval=0)
+
+    def test_batch_size_zero(self):
+        with pytest.raises(Exception):
+            StorageObserverConfig(batch_size=0)
+
+    def test_publish_interval_zero(self):
+        with pytest.raises(Exception):
+            MetricsObserverConfig(publish_interval=0)

--- a/tests/unit/test_config/test_plugin_loader_relative_imports.py
+++ b/tests/unit/test_config/test_plugin_loader_relative_imports.py
@@ -1,0 +1,90 @@
+"""Tests for plugin loader relative import support."""
+
+import sys
+
+import pytest
+
+from panther.plugins.core.plugin_loader_utils import PluginManagerUtils
+
+
+class TestComputePackagePath:
+    def test_returns_none_for_standalone_file(self, tmp_path):
+        """File not in a package should return None."""
+        f = tmp_path / "standalone.py"
+        f.write_text("x = 1")
+        assert PluginManagerUtils._compute_package_path(f) is None
+
+    def test_returns_package_name_for_single_level(self, tmp_path):
+        """File in a single package level."""
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        f = pkg / "mod.py"
+        f.write_text("x = 1")
+        assert PluginManagerUtils._compute_package_path(f) == "mypkg"
+
+    def test_returns_dotted_path_for_nested_package(self, tmp_path):
+        """File in a nested package."""
+        outer = tmp_path / "outer"
+        outer.mkdir()
+        (outer / "__init__.py").write_text("")
+        inner = outer / "inner"
+        inner.mkdir()
+        (inner / "__init__.py").write_text("")
+        f = inner / "mod.py"
+        f.write_text("x = 1")
+        assert PluginManagerUtils._compute_package_path(f) == "outer.inner"
+
+
+class TestRelativeImportSupport:
+    def test_module_in_package_gets_package_set(self, tmp_path):
+        """Module loaded from a package should have __package__ set."""
+        pkg = tmp_path / "testpkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "_helper.py").write_text("VALUE = 42")
+        (pkg / "main.py").write_text("from ._helper import VALUE\nresult = VALUE")
+
+        # Add tmp_path to sys.path temporarily so imports can resolve
+        sys.path.insert(0, str(tmp_path))
+        try:
+            module = PluginManagerUtils.load_module_from_file(
+                pkg / "main.py", "testpkg_main"
+            )
+            assert module.__package__ == "testpkg"
+            assert module.result == 42
+        finally:
+            sys.path.pop(0)
+            # Clean up sys.modules
+            for key in list(sys.modules):
+                if "testpkg" in key:
+                    del sys.modules[key]
+
+    def test_standalone_module_has_no_package(self, tmp_path):
+        """Module not in a package should not have __package__ set."""
+        f = tmp_path / "standalone.py"
+        f.write_text("x = 1")
+        try:
+            module = PluginManagerUtils.load_module_from_file(f, "standalone_test")
+            assert not module.__package__  # Empty string or None
+            assert module.x == 1
+        finally:
+            sys.modules.pop("standalone_test", None)
+
+    def test_module_registered_under_both_names(self, tmp_path):
+        """Module in a package should be in sys.modules under both names."""
+        pkg = tmp_path / "regpkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "mod.py").write_text("x = 1")
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            PluginManagerUtils.load_module_from_file(pkg / "mod.py", "regpkg_mod")
+            assert "regpkg_mod" in sys.modules
+            assert "regpkg.mod" in sys.modules
+        finally:
+            sys.path.pop(0)
+            for key in list(sys.modules):
+                if "regpkg" in key:
+                    del sys.modules[key]

--- a/tests/unit/test_config/test_protocol_enums.py
+++ b/tests/unit/test_config/test_protocol_enums.py
@@ -1,0 +1,52 @@
+"""Tests for protocol config enums and constraints."""
+
+import pytest
+
+from panther.config.core.models.protocol import (
+    ClientServerProtocolConfig,
+    CongestionControl,
+    HttpMethod,
+    HttpVersion,
+    PeerToPeerProtocolConfig,
+    TlsVerifyMode,
+)
+
+
+class TestProtocolEnums:
+    def test_http_method_valid(self):
+        for val in ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]:
+            assert HttpMethod(val).value == val
+
+    def test_http_version_valid(self):
+        for val in ["1.0", "1.1", "2", "3"]:
+            assert HttpVersion(val).value == val
+
+    def test_tls_verify_mode_valid(self):
+        for val in ["none", "optional", "required"]:
+            assert TlsVerifyMode(val).value == val
+
+    def test_congestion_control_valid(self):
+        for val in ["reno", "cubic", "bbr", "bbr2"]:
+            assert CongestionControl(val).value == val
+
+    def test_config_accepts_string_method(self):
+        c = ClientServerProtocolConfig(name="http", method="POST")
+        assert c.method == HttpMethod.POST
+
+
+class TestProtocolConstraints:
+    def test_initial_max_data_negative(self):
+        with pytest.raises(Exception):
+            ClientServerProtocolConfig(name="quic", initial_max_data=-1)
+
+    def test_retry_count_too_high(self):
+        with pytest.raises(Exception):
+            ClientServerProtocolConfig(name="quic", retry_count=101)
+
+    def test_max_peers_zero(self):
+        with pytest.raises(Exception):
+            PeerToPeerProtocolConfig(name="bt", max_peers=0)
+
+    def test_ping_interval_zero(self):
+        with pytest.raises(Exception):
+            PeerToPeerProtocolConfig(name="bt", ping_interval=0)

--- a/tests/unit/test_config/test_service_config_base.py
+++ b/tests/unit/test_config/test_service_config_base.py
@@ -1,8 +1,8 @@
-"""Tests for ServiceConfig after PR2 field merge."""
+"""Tests for ServiceConfig after PR2 field merge, plus enums, constraints, and metadata."""
 
 import pytest
 
-from panther.config.core.models.service import ServiceConfig
+from panther.config.core.models.service import RestartPolicy, ServiceConfig
 
 
 class TestServiceConfigMergedFields:
@@ -46,3 +46,70 @@ class TestOldClassesRemoved:
         from panther.config.core.models import plugin
 
         assert not hasattr(plugin, "BasePluginConfig")
+
+
+class TestRestartPolicyEnum:
+    def test_valid_values(self):
+        for val in ["no", "always", "on-failure", "unless-stopped"]:
+            assert RestartPolicy(val) == RestartPolicy(val)
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            RestartPolicy("invalid")
+
+    def test_service_config_accepts_string(self):
+        sc = ServiceConfig(
+            implementation={"name": "test", "type": "iut"},
+            protocol={"name": "quic", "role": "server"},
+            restart_policy="always",
+        )
+        # BaseConfig has use_enum_values=True, so the value is stored as a string
+        assert sc.restart_policy == RestartPolicy.ALWAYS.value
+
+    def test_service_config_default(self):
+        sc = ServiceConfig(
+            implementation={"name": "test", "type": "iut"},
+            protocol={"name": "quic", "role": "server"},
+        )
+        # BaseConfig has use_enum_values=True, so the value is stored as a string
+        assert sc.restart_policy == RestartPolicy.NO.value
+
+
+class TestServiceFieldConstraints:
+    def test_port_too_high(self):
+        with pytest.raises(Exception):
+            ServiceConfig(
+                implementation={"name": "test", "type": "iut"},
+                protocol={"name": "quic", "role": "server"},
+                network={"port": 99999},
+            )
+
+    def test_port_zero(self):
+        with pytest.raises(Exception):
+            ServiceConfig(
+                implementation={"name": "test", "type": "iut"},
+                protocol={"name": "quic", "role": "server"},
+                network={"port": 0},
+            )
+
+    def test_timeout_too_high(self):
+        with pytest.raises(Exception):
+            ServiceConfig(
+                implementation={"name": "test", "type": "iut"},
+                protocol={"name": "quic", "role": "server"},
+                timeout=100000,
+            )
+
+    def test_protocol_name_empty(self):
+        with pytest.raises(Exception):
+            ServiceConfig(
+                implementation={"name": "test", "type": "iut"},
+                protocol={"name": "", "role": "server"},
+            )
+
+    def test_impl_name_empty(self):
+        with pytest.raises(Exception):
+            ServiceConfig(
+                implementation={"name": "", "type": "iut"},
+                protocol={"name": "quic", "role": "server"},
+            )

--- a/tests/unit/test_core/test_fast_fail_configuration.py
+++ b/tests/unit/test_core/test_fast_fail_configuration.py
@@ -1,5 +1,4 @@
-"""
-Tests for fast-fail configuration and behavior customization.
+"""Tests for fast-fail configuration and behavior customization.
 
 This module tests:
 - FastFailConfig schema and validation
@@ -337,12 +336,14 @@ class TestConfigurationValidation:
     """Test configuration validation and edge cases."""
 
     def test_negative_threshold_values(self):
-        """Test handling of negative configuration values."""
-        # FastFailConfig should handle negative values gracefully
-        config = FastFailConfig(timeout_cascade_threshold=-1)
+        """Test that negative threshold values are rejected by ge=1 constraint."""
+        from pydantic import ValidationError
 
-        # Negative should be accepted (validation could convert to 0 in practice)
-        assert config.timeout_cascade_threshold == -1
+        with pytest.raises(ValidationError):
+            FastFailConfig(timeout_cascade_threshold=-1)
+
+        with pytest.raises(ValidationError):
+            FastFailConfig(timeout_cascade_threshold=0)
 
     def test_conflicting_configurations(self):
         """Test handling of conflicting configuration settings."""


### PR DESCRIPTION
## Summary

- **Rename ambiguous validator files**: `universal_validators.py` → `field_coercion.py` (components) and `pydantic_factories.py` (validators) to clarify their distinct roles
- **Add typed enums**: `RestartPolicy`, `DockerNetworkMode`, `ExportFormat`, `StorageFormat`, `ReportFormat`, `HttpMethod`, `HttpVersion`, `TlsVerifyMode`, `CongestionControl` — replacing raw strings with validated types
- **Add field constraints and metadata**: `ge`, `le`, `min_length`, `json_schema_extra` across service, global, observer, experiment, environment, and protocol configs
- **Clean up CompatibilityValidator**: Remove all legacy code paths
- **Fix plugin loader**: Support relative imports in dynamic plugin loading via `_compute_package_path()` with proper `__package__` setup and module caching

## Stats
- 26 files changed, +1179 / -248 lines
- 11 commits

## Test plan
- [ ] `pytest tests/ -n auto -m unit` passes
- [ ] Existing YAML configs still validate correctly
- [ ] json_schema_extra metadata present on config fields

## Summary by Sourcery

Introduce typed enums, field constraints, and rich metadata across config models while simplifying compatibility checks and improving plugin loading behavior.

New Features:
- Add typed enums for restart policies, Docker network modes, export formats, HTTP protocol settings, TLS verification modes, congestion control, storage formats, and report formats in configuration models.
- Expose additional json_schema_extra metadata, examples, and descriptions on core config fields to support richer schema/introspection and UI generation.

Bug Fixes:
- Fix dynamic plugin loading to correctly support relative imports within package-based plugins and ensure proper module caching.

Enhancements:
- Tighten validation across service, global, observer, experiment, environment, protocol, and plugin configs using numeric bounds, non-empty string constraints, and enum-backed logging levels.
- Rename validator modules to clearly distinguish pure field coercion helpers from Pydantic validator factory utilities.
- Simplify the CompatibilityValidator by removing obsolete legacy-format checks while keeping it as an extension point.
- Add targeted unit tests covering new enums, field constraints, json_schema_extra metadata, compatibility validator behavior, and plugin loader relative import handling.

Tests:
- Add comprehensive unit tests validating new enum types, field constraints, observer and experiment limits, environment and plugin constraints, compatibility validator behavior, and plugin loader relative import support, as well as presence of json_schema_extra metadata on key fields.