### PR TITLE
fix: Jinja template crash on phases_completed=None, submodule updates

### DIFF
--- a/docs/superpowers/plans/2026-03-18-uses-calls-edge-analysis.md
+++ b/docs/superpowers/plans/2026-03-18-uses-calls-edge-analysis.md
@@ -1,0 +1,1445 @@
+# USES/CALLS Edge Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CALLS, USES, MONITORS, and CONTAINS edges to the ivy-lsp semantic model, enabling symbol-to-symbol cross-reference analysis for impact analysis and call hierarchy features.
+
+**Architecture:** Extend `ExtractionResult` with a `SymbolReference` list populated by each extraction tier (AST-based for Tier 1, regex for Tier 2/3). Wire references into `SemanticModel` edges in `model_builder`. Refactor `call_hierarchy.py` to query semantic edges instead of brute-force regex scanning.
+
+**Tech Stack:** Python 3.10+, lsprotocol, ivy (optional for Tier 1), pytest
+
+**Root:** All relative paths below are under `panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp/`
+
+**Test command:** `cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp && python -m pytest tests/ -x -q`
+
+---
+
+### Task 1: Add SymbolReference dataclass and CALLS/USES edge types
+
+**Files:**
+- Modify: `ivy_lsp/parsing/symbols.py` (add `SymbolReference` after `IvySymbol` at ~line 58)
+- Modify: `ivy_lsp/semantic/edges.py` (add `CALLS`, `USES` to enum at ~line 36)
+- Test: `tests/test_reference_extraction.py` (NEW)
+
+- [ ] **Step 1: Write failing test for SymbolReference**
+
+Create `tests/test_reference_extraction.py`:
+
+```python
+"""Tests for SymbolReference extraction from Ivy source."""
+from __future__ import annotations
+
+import pytest
+
+from ivy_lsp.parsing.symbols import SymbolReference
+
+
+class TestSymbolReference:
+    """SymbolReference dataclass basics."""
+
+    @pytest.mark.unit
+    def test_create_call_reference(self):
+        ref = SymbolReference(
+            source_name="process",
+            target_name="connect",
+            kind="call",
+            line=7,
+            col=4,
+            file_path="/tmp/proto.ivy",
+        )
+        assert ref.source_name == "process"
+        assert ref.target_name == "connect"
+        assert ref.kind == "call"
+
+    @pytest.mark.unit
+    def test_create_instance_reference(self):
+        ref = SymbolReference(
+            source_name="client",
+            target_name="endpoint.client_endpoint",
+            kind="instance",
+            line=3,
+        )
+        assert ref.kind == "instance"
+
+    @pytest.mark.unit
+    def test_create_monitor_reference(self):
+        ref = SymbolReference(
+            source_name="before connect",
+            target_name="connect",
+            kind="monitor",
+            line=10,
+        )
+        assert ref.kind == "monitor"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_reference_extraction.py::TestSymbolReference -v`
+Expected: `ImportError: cannot import name 'SymbolReference' from 'ivy_lsp.parsing.symbols'`
+
+- [ ] **Step 3: Implement SymbolReference in symbols.py**
+
+Add after line 58 (after `IvySymbol.from_dict`) in `ivy_lsp/parsing/symbols.py`:
+
+```python
+# In the existing import on line 12, add Literal:
+# from typing import Dict, List, Literal, Optional, Set, Tuple
+
+@dataclass
+class SymbolReference:
+    """A reference from one symbol's scope to another symbol.
+
+    Attributes:
+        source_name: Qualified name of the containing symbol.
+        target_name: Name of the referenced symbol (may be unqualified).
+        kind: The type of reference.
+        line: 0-based line number where the reference occurs.
+        col: 0-based column of the reference token.
+        file_path: File where the reference is found.
+    """
+
+    source_name: str
+    target_name: str
+    kind: Literal["call", "instance", "monitor"]
+    line: int
+    col: int = 0
+    file_path: Optional[str] = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_reference_extraction.py::TestSymbolReference -v`
+Expected: 3 passed
+
+- [ ] **Step 5: Write failing test for new edge types**
+
+Add to `tests/test_reference_extraction.py`:
+
+```python
+from ivy_lsp.semantic.edges import SemanticEdgeType
+
+
+class TestEdgeTypes:
+    @pytest.mark.unit
+    def test_calls_edge_type_exists(self):
+        assert SemanticEdgeType.CALLS.value == "calls"
+
+    @pytest.mark.unit
+    def test_uses_edge_type_exists(self):
+        assert SemanticEdgeType.USES.value == "uses"
+
+    @pytest.mark.unit
+    def test_monitors_edge_type_exists(self):
+        """MONITORS already exists but verify it's there."""
+        assert SemanticEdgeType.MONITORS.value == "monitors"
+
+    @pytest.mark.unit
+    def test_contains_edge_type_exists(self):
+        """CONTAINS already exists but verify it's there."""
+        assert SemanticEdgeType.CONTAINS.value == "contains"
+```
+
+- [ ] **Step 6: Run test to verify CALLS/USES fail**
+
+Run: `python -m pytest tests/test_reference_extraction.py::TestEdgeTypes -v`
+Expected: FAIL for `test_calls_edge_type_exists` and `test_uses_edge_type_exists`
+
+- [ ] **Step 7: Add CALLS and USES to SemanticEdgeType**
+
+In `ivy_lsp/semantic/edges.py`, add after line 36 (`COVERS = "covers"`):
+
+```python
+    CALLS = "calls"  # action A invokes action B
+    USES = "uses"  # instance X instantiates module Y
+```
+
+- [ ] **Step 8: Run all tests to verify pass + no regressions**
+
+Run: `python -m pytest tests/test_reference_extraction.py -v && python -m pytest tests/ -x -q`
+Expected: All pass (2191+ tests)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add ivy_lsp/parsing/symbols.py ivy_lsp/semantic/edges.py tests/test_reference_extraction.py
+git commit -m "feat: add SymbolReference dataclass and CALLS/USES edge types"
+```
+
+---
+
+### Task 2: Extend ExtractionResult with references and add Tier 3 regex extraction
+
+**Files:**
+- Modify: `ivy_lsp/parsing/tiered_extractor.py` (extend ExtractionResult, add regex ref extraction to `_try_regex`)
+- Test: `tests/test_reference_extraction.py` (add Tier 3 tests)
+
+- [ ] **Step 1: Write failing tests for Tier 3 reference extraction**
+
+Add to `tests/test_reference_extraction.py`:
+
+```python
+from ivy_lsp.parsing.tiered_extractor import TieredExtractor
+
+
+SAMPLE_IVY = """\
+#lang ivy1.7
+
+type cid
+
+action connect(src:cid, dst:cid)
+
+action process(c:cid) = {
+    call connect(c, c);
+}
+
+instance client : endpoint.quic_ep(addr, port)
+
+before connect {
+    require src ~= dst;
+}
+"""
+
+
+class TestTier3ReferenceExtraction:
+    """Tier 3 (regex) should extract SymbolReferences."""
+
+    @pytest.mark.unit
+    def test_extraction_result_has_references_field(self):
+        ext = TieredExtractor()
+        result = ext.extract(SAMPLE_IVY, "/tmp/test.ivy")
+        assert hasattr(result, "references")
+        assert isinstance(result.references, list)
+
+    @pytest.mark.unit
+    def test_extracts_call_reference(self):
+        ext = TieredExtractor()
+        result = ext.extract(SAMPLE_IVY, "/tmp/test.ivy")
+        calls = [r for r in result.references if r.kind == "call"]
+        assert len(calls) >= 1
+        assert any(r.target_name == "connect" for r in calls)
+
+    @pytest.mark.unit
+    def test_extracts_instance_reference(self):
+        ext = TieredExtractor()
+        result = ext.extract(SAMPLE_IVY, "/tmp/test.ivy")
+        instances = [r for r in result.references if r.kind == "instance"]
+        assert len(instances) >= 1
+        assert any(r.source_name == "client" for r in instances)
+        assert any(r.target_name == "endpoint.quic_ep" for r in instances)
+
+    @pytest.mark.unit
+    def test_extracts_monitor_reference(self):
+        ext = TieredExtractor()
+        result = ext.extract(SAMPLE_IVY, "/tmp/test.ivy")
+        monitors = [r for r in result.references if r.kind == "monitor"]
+        assert len(monitors) >= 1
+        assert any(r.target_name == "connect" for r in monitors)
+
+    @pytest.mark.unit
+    def test_call_reference_has_source_name(self):
+        ext = TieredExtractor()
+        result = ext.extract(SAMPLE_IVY, "/tmp/test.ivy")
+        calls = [r for r in result.references if r.kind == "call"]
+        # The call to connect is inside action process
+        assert any(r.source_name == "process" for r in calls)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_reference_extraction.py::TestTier3ReferenceExtraction -v`
+Expected: FAIL (no `references` attribute or empty list)
+
+- [ ] **Step 3: Add `references` field to ExtractionResult**
+
+In `ivy_lsp/parsing/tiered_extractor.py`:
+
+Add import at top:
+```python
+from ivy_lsp.parsing.symbols import IvySymbol, SymbolReference
+```
+
+Add field to `ExtractionResult` (after `includes` field):
+```python
+    references: List[SymbolReference] = field(default_factory=list)
+```
+
+- [ ] **Step 4: Add regex patterns and extraction helpers**
+
+Add module-level regexes after existing pattern definitions (~line 89):
+
+```python
+# Reference extraction patterns (Tier 3 / Tier 2 fallback)
+_CALL_STMT_RE = re.compile(r"call\s+([\w.]+)\s*\(", re.MULTILINE)
+_INSTANCE_RE = re.compile(r"^\s*instance\s+([\w.]+)\s*:\s*([\w.]+)", re.MULTILINE)
+_MONITOR_RE = re.compile(r"^\s*(before|after|around)\s+([\w.]+)", re.MULTILINE)
+```
+
+Add helper function before `TieredExtractor` class:
+
+```python
+def _find_enclosing_action(
+    line_no: int,
+    symbols: List[IvySymbol],
+) -> Optional[str]:
+    """Find the action symbol whose range encloses *line_no*.
+
+    Returns the action name or None if no enclosing action is found.
+    """
+    best_name: Optional[str] = None
+    best_line = -1
+    for sym in symbols:
+        if sym.kind != SymbolKind.Function:
+            continue
+        sym_line = sym.range[0]
+        if sym_line <= line_no and sym_line > best_line:
+            best_name = sym.name
+            best_line = sym_line
+    return best_name
+
+
+def _extract_references_regex(
+    source: str,
+    filepath: str,
+    symbols: List[IvySymbol],
+) -> List[SymbolReference]:
+    """Extract SymbolReferences using regex patterns (Tier 2/3 fallback)."""
+    refs: List[SymbolReference] = []
+    lines = source.split("\n")
+
+    # CALLS: explicit "call foo(...)" statements
+    for m in _CALL_STMT_RE.finditer(source):
+        target = m.group(1)
+        line_no = source[: m.start()].count("\n")
+        col = m.start() - source.rfind("\n", 0, m.start()) - 1
+        enclosing = _find_enclosing_action(line_no, symbols)
+        if enclosing and enclosing != target.split(".")[-1]:
+            refs.append(
+                SymbolReference(
+                    source_name=enclosing,
+                    target_name=target,
+                    kind="call",
+                    line=line_no,
+                    col=col,
+                    file_path=filepath,
+                )
+            )
+
+    # INSTANCES: "instance X : module.name(...)"
+    for m in _INSTANCE_RE.finditer(source):
+        instance_name = m.group(1)
+        module_name = m.group(2)
+        line_no = source[: m.start()].count("\n")
+        refs.append(
+            SymbolReference(
+                source_name=instance_name,
+                target_name=module_name,
+                kind="instance",
+                line=line_no,
+                file_path=filepath,
+            )
+        )
+
+    # MONITORS: "before/after/around action_name"
+    for m in _MONITOR_RE.finditer(source):
+        monitor_kind = m.group(1)
+        target_action = m.group(2)
+        line_no = source[: m.start()].count("\n")
+        refs.append(
+            SymbolReference(
+                source_name=f"{monitor_kind} {target_action}",
+                target_name=target_action,
+                kind="monitor",
+                line=line_no,
+                file_path=filepath,
+            )
+        )
+
+    return refs
+```
+
+- [ ] **Step 5: Update `_try_regex()` to return references**
+
+Change `_try_regex()` return type and body (the last 2 lines):
+
+```python
+    def _try_regex(
+        self, source: str, filepath: str
+    ) -> Tuple[List[IvySymbol], List[str], List[SymbolReference]]:
+        """Tier 3: Regex-based extraction (always succeeds)."""
+        # ... existing symbol extraction code stays the same ...
+
+        # Includes
+        includes = INCLUDE_PATTERN.findall(source)
+
+        # References (new)
+        references = _extract_references_regex(source, filepath, symbols)
+
+        return symbols, includes, references
+```
+
+- [ ] **Step 6: Update `_try_lexer()` to return references**
+
+Change return type and add reference extraction at end of `_try_lexer()`:
+
+```python
+    def _try_lexer(
+        self, source: str, filepath: str
+    ) -> Tuple[List[IvySymbol], List[str], List[SymbolReference]]:
+        # ... existing code ...
+
+        # Extract references using regex fallback (lexer doesn't provide body analysis)
+        references = _extract_references_regex(source, filepath, declaration_symbols)
+
+        return declaration_symbols, includes, references
+```
+
+- [ ] **Step 7: Update `_try_parser()` to return references**
+
+Change return type (references will be added in Task 3; for now return empty):
+
+```python
+    def _try_parser(
+        self, source: str, filepath: str
+    ) -> Tuple[List[IvySymbol], List[str], List[SymbolReference]]:
+        # ... existing code ...
+        return symbols, includes, []  # AST references added in Task 3
+```
+
+- [ ] **Step 8: Update `extract()` to unpack the third element**
+
+In the `extract()` method, update all three tier success paths to unpack `references`.
+The unpack lines are at approximately: line 147 (Tier 1), line 190 (Tier 2), and line 231 (Tier 3) of `tiered_extractor.py`.
+Change `symbols, includes = self._try_*()` to `symbols, includes, references = self._try_*()` and add `references=references` to the `ExtractionResult` constructor:
+
+```python
+        # Tier 1 success path:
+        symbols, includes, references = self._try_parser(source, filepath)
+        # ...
+        return ExtractionResult(
+            symbols=symbols, includes=includes, references=references,
+            tier_used=1, timing_ms=elapsed, errors=errors,
+        )
+
+        # Tier 2 success path:
+        symbols, includes, references = self._try_lexer(source, filepath)
+        # ...
+        return ExtractionResult(
+            symbols=symbols, includes=includes, references=references,
+            tier_used=2, timing_ms=elapsed, errors=errors,
+        )
+
+        # Tier 3 success path:
+        symbols, includes, references = self._try_regex(source, filepath)
+        # ...
+        return ExtractionResult(
+            symbols=symbols, includes=includes, references=references,
+            tier_used=3, timing_ms=elapsed, errors=errors,
+        )
+```
+
+- [ ] **Step 9: Run tests to verify pass + no regressions**
+
+Run: `python -m pytest tests/test_reference_extraction.py -v && python -m pytest tests/ -x -q`
+Expected: All pass
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add ivy_lsp/parsing/tiered_extractor.py tests/test_reference_extraction.py
+git commit -m "feat: extend ExtractionResult with references, add Tier 3 regex extraction"
+```
+
+---
+
+### Task 3: Add Tier 1 AST reference extraction
+
+**Files:**
+- Modify: `ivy_lsp/parsing/ast_to_symbols.py` (add `extract_references_from_ast()`)
+- Modify: `ivy_lsp/parsing/tiered_extractor.py` (wire into `_try_parser()`)
+- Test: `tests/test_reference_extraction.py` (add AST extraction tests)
+
+- [ ] **Step 1: Write failing test for AST reference extraction**
+
+Add to `tests/test_reference_extraction.py`:
+
+```python
+class TestTier1ASTReferenceExtraction:
+    """Tier 1 (AST) should extract SymbolReferences from parsed AST."""
+
+    @pytest.mark.unit
+    def test_extract_references_from_ast_importable(self):
+        from ivy_lsp.parsing.ast_to_symbols import extract_references_from_ast
+        assert callable(extract_references_from_ast)
+
+    @pytest.mark.unit
+    def test_ast_extracts_call_references(self):
+        """If Ivy parser is available, AST extraction should find calls."""
+        try:
+            from ivy_lsp.parsing.parser_session import IvyParserWrapper
+        except ImportError:
+            pytest.skip("Ivy parser not available")
+
+        from ivy_lsp.parsing.ast_to_symbols import extract_references_from_ast
+
+        source = (
+            "#lang ivy1.7\n"
+            "type cid\n"
+            "action connect(src:cid, dst:cid)\n"
+            "action process(c:cid) = {\n"
+            "    call connect(c, c);\n"
+            "}\n"
+        )
+        wrapper = IvyParserWrapper()
+        result = wrapper.parse(source, filename="/tmp/test.ivy", timeout=5.0)
+        if not result.success or result.ast is None:
+            pytest.skip("Parse failed")
+
+        refs = extract_references_from_ast(result.ast, "/tmp/test.ivy", source)
+        calls = [r for r in refs if r.kind == "call"]
+        assert len(calls) >= 1
+        assert any(r.target_name == "connect" for r in calls)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_reference_extraction.py::TestTier1ASTReferenceExtraction -v`
+Expected: `ImportError: cannot import name 'extract_references_from_ast'`
+
+- [ ] **Step 3: Implement `extract_references_from_ast()`**
+
+Add to `ivy_lsp/parsing/ast_to_symbols.py` after the `ast_to_symbols()` function:
+
+```python
+def extract_references_from_ast(
+    ivy_obj: Any, filename: str, source: str
+) -> List["SymbolReference"]:
+    """Extract cross-references (calls, instances, monitors) from a parsed Ivy AST.
+
+    Walks the same declaration list as ``ast_to_symbols()`` but extracts
+    references rather than symbol definitions.
+    """
+    from ivy_lsp.parsing.symbols import SymbolReference
+
+    if ivy_obj is None or not hasattr(ivy_obj, "decls"):
+        return []
+
+    refs: List[SymbolReference] = []
+    abs_filename = os.path.abspath(filename) if filename else filename
+
+    for decl in ivy_obj.decls:
+        try:
+            if is_from_included_file(decl, abs_filename):
+                continue
+            refs.extend(_extract_refs_from_decl(decl, filename))
+        except Exception:
+            logger.debug(
+                "Failed to extract references from %s in %s",
+                type(decl).__name__,
+                filename,
+                exc_info=True,
+            )
+
+    return refs
+
+
+def _extract_refs_from_decl(decl: Any, filename: str) -> List["SymbolReference"]:
+    """Extract references from a single AST declaration."""
+    import ivy.ivy_ast as ia
+
+    from ivy_lsp.parsing.symbols import SymbolReference
+
+    refs: List[SymbolReference] = []
+
+    # CALLS: walk action bodies for CallAction nodes
+    if isinstance(decl, ia.ActionDecl):
+        defs = decl.defines()
+        if not defs:
+            return refs
+        action_name = defs[0][0]
+        try:
+            action_def = decl.args[0]  # ActionDef
+            body = getattr(action_def, "body", None)
+            if body is not None:
+                refs.extend(
+                    _extract_calls_from_body(body, action_name, filename)
+                )
+        except (IndexError, AttributeError):
+            pass
+
+    # USES: instance declarations
+    elif isinstance(decl, ia.InstantiateDecl):
+        defs = decl.defines()
+        if defs:
+            instance_name = defs[0][0]
+            module_name = _extract_instantiate_target(decl)
+            if module_name:
+                lineno = getattr(decl, "lineno", None)
+                line = (getattr(lineno, "line", 0) or 0) - 1
+                refs.append(
+                    SymbolReference(
+                        source_name=instance_name,
+                        target_name=module_name,
+                        kind="instance",
+                        line=max(0, line),
+                        file_path=filename,
+                    )
+                )
+
+    # MONITORS: mixin declarations (before/after/around)
+    elif isinstance(decl, ia.MixinDecl):
+        mixer_name, mixee_name, kind = _extract_mixin_info(decl)
+        if mixer_name and mixee_name:
+            lineno = getattr(decl, "lineno", None)
+            line = (getattr(lineno, "line", 0) or 0) - 1
+            refs.append(
+                SymbolReference(
+                    source_name=f"{kind} {mixee_name}" if kind else mixer_name,
+                    target_name=mixee_name,
+                    kind="monitor",
+                    line=max(0, line),
+                    file_path=filename,
+                )
+            )
+
+    return refs
+
+
+def _extract_calls_from_body(
+    body: Any, action_name: str, filename: str
+) -> List["SymbolReference"]:
+    """Recursively walk an action body AST to find call references."""
+    from ivy_lsp.parsing.symbols import SymbolReference
+
+    refs: List[SymbolReference] = []
+
+    try:
+        import ivy.ivy_actions as iact
+    except ImportError:
+        return refs
+
+    if isinstance(body, iact.CallAction):
+        if body.args:
+            callee_atom = body.args[0]
+            callee = getattr(callee_atom, "relname", None)
+            if callee and callee != action_name:
+                lineno = getattr(body, "lineno", None)
+                line = (getattr(lineno, "line", 0) or 0) - 1
+                refs.append(
+                    SymbolReference(
+                        source_name=action_name,
+                        target_name=callee,
+                        kind="call",
+                        line=max(0, line),
+                        file_path=filename,
+                    )
+                )
+
+    # Recurse into compound actions
+    for arg in getattr(body, "args", ()):
+        if arg is not None:
+            refs.extend(_extract_calls_from_body(arg, action_name, filename))
+
+    return refs
+
+
+def _extract_instantiate_target(decl: Any) -> Optional[str]:
+    """Extract the module name from an InstantiateDecl."""
+    try:
+        app = decl.args[0]  # The application expression
+        func = getattr(app, "func", None) or (app.args[0] if app.args else None)
+        name = getattr(func, "relname", None) or getattr(func, "rep", None)
+        return str(name) if name else None
+    except (IndexError, AttributeError):
+        return None
+
+
+def _extract_mixin_info(decl: Any) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Extract (mixer_name, mixee_name, kind) from a MixinDecl.
+
+    Returns (None, None, None) on failure.
+    """
+    try:
+        mixer_atom = decl.args[0] if decl.args else None
+        mixer_name = _atom_name(mixer_atom) if mixer_atom else None
+        mixee = getattr(decl, "mixee", None)
+        mixee_name = _atom_name(mixee) if mixee else None
+        kind = getattr(decl, "kind", None)
+        if kind is None:
+            # Heuristic: check mixer name for before/after prefix
+            if mixer_name:
+                for prefix in ("before_", "after_", "around_"):
+                    if mixer_name.startswith(prefix):
+                        kind = prefix.rstrip("_")
+                        break
+        return mixer_name, mixee_name, kind
+    except (IndexError, AttributeError):
+        return None, None, None
+```
+
+- [ ] **Step 4: Wire into `_try_parser()` in tiered_extractor.py**
+
+Update `_try_parser()` to call `extract_references_from_ast()`:
+
+```python
+    def _try_parser(
+        self, source: str, filepath: str
+    ) -> Tuple[List[IvySymbol], List[str], List[SymbolReference]]:
+        from ivy_lsp.parsing.ast_to_symbols import ast_to_symbols, extract_references_from_ast
+        from ivy_lsp.parsing.parser_session import IvyParserWrapper
+
+        wrapper = IvyParserWrapper(resolve_callback=self._resolve_callback)
+        result = wrapper.parse(source, filename=filepath, timeout=self._parser_timeout)
+
+        if not result.success or result.ast is None:
+            error_msgs = [str(e) for e in result.errors[:3]]
+            raise RuntimeError(
+                f"Parse failed with {len(result.errors)} error(s): "
+                + "; ".join(error_msgs)
+            )
+
+        symbols = ast_to_symbols(result.ast, filepath, source)
+        includes = _extract_includes_from_ast(result.ast)
+        references = extract_references_from_ast(result.ast, filepath, source)
+
+        return symbols, includes, references
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_reference_extraction.py -v && python -m pytest tests/ -x -q`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ivy_lsp/parsing/ast_to_symbols.py ivy_lsp/parsing/tiered_extractor.py tests/test_reference_extraction.py
+git commit -m "feat: add Tier 1 AST reference extraction for CALLS, USES, MONITORS"
+```
+
+---
+
+### Task 4: Wire CALLS, USES, MONITORS, CONTAINS edges in model_builder
+
+**Files:**
+- Modify: `ivy_lsp/semantic/model_builder.py` (add edge wiring sections)
+- Test: `tests/test_semantic_model.py` (add edge wiring tests)
+
+- [ ] **Step 1: Write failing tests for edge wiring**
+
+Add to `tests/test_semantic_model.py` (or create if needed):
+
+```python
+"""Tests for CALLS/USES/MONITORS/CONTAINS edge wiring in model_builder."""
+import pytest
+
+from ivy_lsp.parsing.symbols import SymbolReference
+from ivy_lsp.semantic.edges import SemanticEdgeType
+from ivy_lsp.semantic.model import SemanticModel
+from ivy_lsp.semantic.nodes import SymbolNode
+
+
+def _make_model_with_symbols():
+    """Build a minimal SemanticModel with action symbols for edge testing."""
+    model = SemanticModel()
+    model.add_node(
+        SymbolNode(
+            id="/tmp/test.ivy:5:connect",
+            name="connect",
+            qualified_name="connect",
+            kind="action",
+            file="/tmp/test.ivy",
+            line=5,
+        )
+    )
+    model.add_node(
+        SymbolNode(
+            id="/tmp/test.ivy:8:process",
+            name="process",
+            qualified_name="process",
+            kind="action",
+            file="/tmp/test.ivy",
+            line=8,
+        )
+    )
+    model.add_node(
+        SymbolNode(
+            id="/tmp/test.ivy:12:endpoint",
+            name="endpoint",
+            qualified_name="endpoint",
+            kind="module",
+            file="/tmp/test.ivy",
+            line=12,
+        )
+    )
+    model.add_node(
+        SymbolNode(
+            id="/tmp/test.ivy:14:client",
+            name="client",
+            qualified_name="client",
+            kind="instance",
+            file="/tmp/test.ivy",
+            line=14,
+        )
+    )
+    # Nested symbol for CONTAINS test
+    model.add_node(
+        SymbolNode(
+            id="/tmp/test.ivy:16:endpoint.send",
+            name="send",
+            qualified_name="endpoint.send",
+            kind="action",
+            file="/tmp/test.ivy",
+            line=16,
+        )
+    )
+    return model
+
+
+class TestEdgeWiring:
+    @pytest.mark.unit
+    def test_calls_edges_wired(self):
+        from ivy_lsp.semantic.model_builder import _wire_semantic_edges
+
+        model = _make_model_with_symbols()
+        refs = [
+            SymbolReference(
+                source_name="process",
+                target_name="connect",
+                kind="call",
+                line=9,
+                file_path="/tmp/test.ivy",
+            )
+        ]
+        _wire_semantic_edges(model, {}, {}, {"/tmp/test.ivy": refs})
+        outgoing = model.get_outgoing(
+            "/tmp/test.ivy:8:process", SemanticEdgeType.CALLS
+        )
+        assert len(outgoing) == 1
+        assert outgoing[0][1] == "/tmp/test.ivy:5:connect"
+
+    @pytest.mark.unit
+    def test_uses_edges_wired(self):
+        from ivy_lsp.semantic.model_builder import _wire_semantic_edges
+
+        model = _make_model_with_symbols()
+        refs = [
+            SymbolReference(
+                source_name="client",
+                target_name="endpoint",
+                kind="instance",
+                line=14,
+                file_path="/tmp/test.ivy",
+            )
+        ]
+        _wire_semantic_edges(model, {}, {}, {"/tmp/test.ivy": refs})
+        outgoing = model.get_outgoing(
+            "/tmp/test.ivy:14:client", SemanticEdgeType.USES
+        )
+        assert len(outgoing) == 1
+        assert outgoing[0][1] == "/tmp/test.ivy:12:endpoint"
+
+    @pytest.mark.unit
+    def test_contains_edges_wired_from_qualified_names(self):
+        from ivy_lsp.semantic.model_builder import _wire_semantic_edges
+
+        model = _make_model_with_symbols()
+        _wire_semantic_edges(model, {}, {}, {})
+        outgoing = model.get_outgoing(
+            "/tmp/test.ivy:12:endpoint", SemanticEdgeType.CONTAINS
+        )
+        assert len(outgoing) == 1
+        assert outgoing[0][1] == "/tmp/test.ivy:16:endpoint.send"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_semantic_model.py::TestEdgeWiring -v`
+Expected: `TypeError: _wire_semantic_edges() takes 3 positional arguments but 4 were given` (or similar)
+
+- [ ] **Step 3: Update `_wire_semantic_edges()` signature and add edge wiring**
+
+In `ivy_lsp/semantic/model_builder.py`, update `_wire_semantic_edges`:
+
+1. Add `file_references` parameter
+2. Build symbol name→id index
+3. Add sections 4-7 for CALLS, USES, MONITORS, CONTAINS
+
+```python
+def _wire_semantic_edges(
+    model: Any,
+    basename_to_path: dict[str, str],
+    file_includes: dict[str, list[str]],
+    file_references: dict[str, list] | None = None,
+) -> None:
+    """Wire COVERS, HAS_PARAM, RETURNS_TYPE, INCLUDES, CALLS, USES, MONITORS, CONTAINS edges."""
+    from ivy_lsp.semantic.edges import SemanticEdgeType
+    from ivy_lsp.semantic.nodes import (
+        RfcAnnotation,
+        RfcRequirement,
+        SymbolNode,
+        TypeNode,
+    )
+    from ivy_lsp.semantic.rfc_annotations import normalize_tag_to_manifest_ids
+
+    # ... existing sections 1-3 (COVERS, HAS_PARAM/RETURNS_TYPE, INCLUDES) unchanged ...
+
+    # -- Build symbol name index for cross-reference resolution --
+    symbol_by_name: dict[str, str] = {}
+    symbol_by_qname: dict[str, str] = {}
+    for sn in model.get_nodes_by_type(SymbolNode):
+        symbol_by_name.setdefault(sn.name, sn.id)
+        symbol_by_qname[sn.qualified_name] = sn.id
+
+    def _resolve(name: str) -> str | None:
+        return symbol_by_qname.get(name) or symbol_by_name.get(name)
+
+    # 4. CALLS / USES / MONITORS from extracted references
+    if file_references:
+        for refs in file_references.values():
+            for ref in refs:
+                src_id = _resolve(ref.source_name)
+                tgt_id = _resolve(ref.target_name)
+                if not src_id or not tgt_id:
+                    continue
+                if ref.kind == "call":
+                    model.add_edge(src_id, SemanticEdgeType.CALLS, tgt_id)
+                elif ref.kind == "instance":
+                    model.add_edge(src_id, SemanticEdgeType.USES, tgt_id)
+                elif ref.kind == "monitor":
+                    model.add_edge(src_id, SemanticEdgeType.MONITORS, tgt_id)
+
+    # 5. CONTAINS from qualified name hierarchy
+    for sn in model.get_nodes_by_type(SymbolNode):
+        if "." in sn.qualified_name:
+            parent_qname = sn.qualified_name.rsplit(".", 1)[0]
+            parent_id = symbol_by_qname.get(parent_qname)
+            if parent_id:
+                model.add_edge(parent_id, SemanticEdgeType.CONTAINS, sn.id)
+    for tn in model.get_nodes_by_type(TypeNode):
+        if "." in tn.qualified_name:
+            parent_qname = tn.qualified_name.rsplit(".", 1)[0]
+            parent_id = symbol_by_qname.get(parent_qname)
+            if parent_id:
+                model.add_edge(parent_id, SemanticEdgeType.CONTAINS, tn.id)
+```
+
+- [ ] **Step 4: Update `build_semantic_model()` to cache and pass references**
+
+Add `file_references` dict alongside `file_includes`, cache `result.references`, pass to `_wire_semantic_edges`:
+
+```python
+    file_references: dict[str, list] = {}
+    # ... in the scan loop, after file_includes[abs_path] = result.includes:
+    file_references[abs_path] = result.references
+
+    # ... at the end:
+    _wire_semantic_edges(model, basename_to_path, file_includes, file_references)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_semantic_model.py::TestEdgeWiring -v && python -m pytest tests/ -x -q`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ivy_lsp/semantic/model_builder.py tests/test_semantic_model.py
+git commit -m "feat: wire CALLS, USES, MONITORS, CONTAINS edges in model_builder"
+```
+
+---
+
+### Task 5: Wire Tier 3 compiled edges in graph_enrichment
+
+**Files:**
+- Modify: `ivy_lsp/compilation/graph_enrichment.py`
+- Test: `tests/test_graph_enrichment.py` (update)
+
+- [ ] **Step 1: Write failing test for MONITORS edges from ir.mixins**
+
+Add to `tests/test_graph_enrichment.py`:
+
+```python
+@pytest.mark.unit
+def test_monitors_edges_from_mixins():
+    from ivy_lsp.compilation.graph_enrichment import enrich_semantic_model
+    from ivy_lsp.compilation.ir import ActionIR, CompiledModuleIR, MixinIR
+    from ivy_lsp.semantic.edges import SemanticEdgeType
+    from ivy_lsp.semantic.model import SemanticModel
+
+    model = SemanticModel()
+    ir = CompiledModuleIR(
+        actions={
+            "connect": ActionIR(name="connect"),
+            "ext:before_connect": ActionIR(name="ext:before_connect"),
+        },
+        mixins={
+            "connect": (
+                MixinIR(mixer="ext:before_connect", mixee="connect", kind="before"),
+            ),
+        },
+        success=True,
+        source_file="/tmp/test.ivy",
+    )
+    enrich_semantic_model(model, ir, "/tmp/test.ivy")
+
+    mixer_id = "compiled:/tmp/test.ivy:ext:before_connect"
+    outgoing = model.get_outgoing(mixer_id, SemanticEdgeType.MONITORS)
+    assert len(outgoing) >= 1
+
+
+@pytest.mark.unit
+def test_contains_edges_from_hierarchy():
+    from ivy_lsp.compilation.graph_enrichment import enrich_semantic_model
+    from ivy_lsp.compilation.ir import ActionIR, CompiledModuleIR
+    from ivy_lsp.semantic.edges import SemanticEdgeType
+    from ivy_lsp.semantic.model import SemanticModel
+
+    model = SemanticModel()
+    ir = CompiledModuleIR(
+        actions={
+            "packet": ActionIR(name="packet"),
+            "packet.encode": ActionIR(name="packet.encode"),
+        },
+        hierarchy={"packet": frozenset({"packet.encode"})},
+        success=True,
+        source_file="/tmp/test.ivy",
+    )
+    enrich_semantic_model(model, ir, "/tmp/test.ivy")
+
+    parent_id = "compiled:/tmp/test.ivy:packet"
+    outgoing = model.get_outgoing(parent_id, SemanticEdgeType.CONTAINS)
+    assert len(outgoing) >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_graph_enrichment.py::test_monitors_edges_from_mixins tests/test_graph_enrichment.py::test_contains_edges_from_hierarchy -v`
+Expected: FAIL (no MONITORS/CONTAINS edges)
+
+- [ ] **Step 3: Add MONITORS and CONTAINS edge wiring to `enrich_semantic_model()`**
+
+In `ivy_lsp/compilation/graph_enrichment.py`, add after the Actions section (before `model.update_file`):
+
+```python
+    # --- Mixins -> MONITORS edges ---
+    for action_name, mixin_tuple in ir.mixins.items():
+        for mixin in mixin_tuple:
+            mixer_id = f"compiled:{filepath}:{mixin.mixer}"
+            mixee_id = f"compiled:{filepath}:{mixin.mixee}"
+            edges.append((mixer_id, SemanticEdgeType.MONITORS, mixee_id))
+
+    # --- Hierarchy -> CONTAINS edges ---
+    # Note: parent_name may be a module/object only in ir.symbols, not ir.actions.
+    # Build a set of all known node IDs to guard against orphan edges.
+    known_ids = {f"compiled:{filepath}:{n}" for n in (*ir.actions, *ir.symbols, *ir.sorts)}
+    for parent_name, children in ir.hierarchy.items():
+        parent_id = f"compiled:{filepath}:{parent_name}"
+        if parent_id not in known_ids:
+            continue
+        for child_name in children:
+            child_id = f"compiled:{filepath}:{child_name}"
+            if child_id in known_ids:
+                edges.append((parent_id, SemanticEdgeType.CONTAINS, child_id))
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_graph_enrichment.py -v && python -m pytest tests/ -x -q`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ivy_lsp/compilation/graph_enrichment.py tests/test_graph_enrichment.py
+git commit -m "feat: wire MONITORS and CONTAINS edges from compiled IR in graph_enrichment"
+```
+
+---
+
+### Task 6: Update traceability tool — remove "not yet implemented" message
+
+**Files:**
+- Modify: `ivy_lsp/tools/traceability.py` (lines 455-462 and 522-526)
+- Modify: `tests/test_tools_traceability.py` (update assertion)
+
+- [ ] **Step 1: Update the test assertion first**
+
+In `tests/test_tools_traceability.py`, change `TestImpactAnalysisNote.test_impact_analysis_has_fx5_note_code`:
+
+```python
+class TestImpactAnalysisNote:
+    def test_impact_analysis_has_fx5_note_code(self):
+        """The impact analysis should report when no edges found."""
+        from ivy_lsp.tools import traceability
+
+        source = Path(traceability.__file__).read_text()
+        # Updated: no longer says "not yet implemented"
+        assert "No cross-reference edges found for this symbol" in source
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_tools_traceability.py::TestImpactAnalysisNote -v`
+Expected: FAIL (old message still present)
+
+- [ ] **Step 3: Update traceability.py**
+
+In `ivy_lsp/tools/traceability.py`:
+
+1. Update the docstring (lines 455-462) — remove the `.. note::` block:
+
+```python
+    async def _ivy_impact_analysis(symbol_name: str) -> str:
+        """Analyze incoming and outgoing edges for a symbol.
+
+        Returns edges from the semantic model graph including COVERS,
+        HAS_PARAM, RETURNS_TYPE, INCLUDES, CALLS, USES, MONITORS,
+        and CONTAINS edges.
+        """
+```
+
+2. Update the fallback note (lines 522-526):
+
+```python
+            else:
+                result["note"] = (
+                    "No cross-reference edges found for this symbol."
+                )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_tools_traceability.py -v && python -m pytest tests/ -x -q`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ivy_lsp/tools/traceability.py tests/test_tools_traceability.py
+git commit -m "fix: replace 'USES/CALLS not implemented' note with accurate message"
+```
+
+---
+
+### Task 7: Refactor call_hierarchy.py to use semantic edges
+
+**Files:**
+- Modify: `ivy_lsp/features/call_hierarchy.py`
+- Modify: `tests/test_call_hierarchy.py` (add model-based tests)
+
+- [ ] **Step 1: Write failing tests for model-based call hierarchy**
+
+Add to `tests/test_call_hierarchy.py`:
+
+```python
+from ivy_lsp.semantic.edges import SemanticEdgeType
+from ivy_lsp.semantic.model import SemanticModel
+from ivy_lsp.semantic.nodes import SymbolNode
+
+
+def _make_model_for_call_hierarchy(tmp_path):
+    """Build a SemanticModel with CALLS edges matching SAMPLE_SOURCE."""
+    filepath = str(tmp_path / "proto.ivy")
+    model = SemanticModel()
+    model.add_node(
+        SymbolNode(
+            id=f"{filepath}:5:connect",
+            name="connect",
+            qualified_name="connect",
+            kind="action",
+            file=filepath,
+            line=5,
+        )
+    )
+    model.add_node(
+        SymbolNode(
+            id=f"{filepath}:7:process",
+            name="process",
+            qualified_name="process",
+            kind="action",
+            file=filepath,
+            line=7,
+        )
+    )
+    # process CALLS connect
+    model.add_edge(
+        f"{filepath}:7:process",
+        SemanticEdgeType.CALLS,
+        f"{filepath}:5:connect",
+    )
+    return model
+
+
+class TestIncomingCallsWithModel:
+    @pytest.mark.unit
+    def test_model_based_incoming_calls(self, tmp_path):
+        ws = _make_workspace(tmp_path, {"proto.ivy": SAMPLE_SOURCE})
+        indexer = _index(ws)
+        filepath = str(tmp_path / "proto.ivy")
+        model = _make_model_for_call_hierarchy(tmp_path)
+        result = get_incoming_calls(indexer, "connect", filepath, model=model)
+        assert len(result) >= 1
+        caller_names = [call.from_.name for call in result]
+        assert "process" in caller_names
+
+    @pytest.mark.unit
+    def test_fallback_when_model_is_none(self, tmp_path):
+        ws = _make_workspace(tmp_path, {"proto.ivy": SAMPLE_SOURCE})
+        indexer = _index(ws)
+        filepath = str(tmp_path / "proto.ivy")
+        result = get_incoming_calls(indexer, "connect", filepath, model=None)
+        # Should still work via regex fallback
+        assert len(result) >= 1
+
+
+class TestOutgoingCallsWithModel:
+    @pytest.mark.unit
+    def test_model_based_outgoing_calls(self, tmp_path):
+        ws = _make_workspace(tmp_path, {"proto.ivy": SAMPLE_SOURCE})
+        indexer = _index(ws)
+        filepath = str(tmp_path / "proto.ivy")
+        model = _make_model_for_call_hierarchy(tmp_path)
+        result = get_outgoing_calls(indexer, "process", filepath, model=model)
+        assert len(result) >= 1
+        callee_names = [call.to.name for call in result]
+        assert "connect" in callee_names
+
+    @pytest.mark.unit
+    def test_fallback_when_model_is_none(self, tmp_path):
+        ws = _make_workspace(tmp_path, {"proto.ivy": SAMPLE_SOURCE})
+        indexer = _index(ws)
+        filepath = str(tmp_path / "proto.ivy")
+        result = get_outgoing_calls(indexer, "process", filepath, model=None)
+        assert len(result) >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_call_hierarchy.py::TestIncomingCallsWithModel tests/test_call_hierarchy.py::TestOutgoingCallsWithModel -v`
+Expected: `TypeError: get_incoming_calls() got an unexpected keyword argument 'model'`
+
+- [ ] **Step 3: Add model parameter and helpers to call_hierarchy.py**
+
+Add helpers after existing helpers section:
+
+```python
+def _find_symbol_node_id(model, name: str, filepath: str) -> Optional[str]:
+    """Find a SymbolNode matching *name* and *filepath* in the model."""
+    from ivy_lsp.semantic.nodes import SymbolNode
+
+    last = name.rsplit(".", 1)[-1] if "." in name else name
+    for sn in model.get_nodes_by_type(SymbolNode):
+        if sn.name == last and sn.file == filepath:
+            return sn.id
+    # Fallback: match by name only (cross-file)
+    for sn in model.get_nodes_by_type(SymbolNode):
+        if sn.name == last:
+            return sn.id
+    return None
+
+
+def _node_to_call_hierarchy_item(model, node_id: str) -> Optional[lsp.CallHierarchyItem]:
+    """Convert a semantic model node_id to a CallHierarchyItem."""
+    node = model.get_node(node_id)
+    if node is None:
+        return None
+    name = getattr(node, "name", "unknown")
+    filepath = getattr(node, "file", "")
+    line = max(0, getattr(node, "line", 1) - 1)  # 1-based to 0-based
+    uri = Path(filepath).as_uri() if filepath else ""
+    r = make_range(line, 0, line, len(name))
+    return lsp.CallHierarchyItem(
+        name=name,
+        kind=lsp.SymbolKind.Function,
+        uri=uri,
+        range=r,
+        selection_range=r,
+        detail=getattr(node, "kind", ""),
+    )
+```
+
+- [ ] **Step 4: Refactor `get_incoming_calls()` with model-first, regex-fallback**
+
+```python
+def get_incoming_calls(
+    indexer,
+    item_name: str,
+    item_filepath: str,
+    model=None,
+) -> List[lsp.CallHierarchyIncomingCall]:
+    """Find all actions/monitors that reference *item_name*."""
+    # Model path: use semantic CALLS/MONITORS edges
+    if model is not None:
+        from ivy_lsp.semantic.edges import SemanticEdgeType
+
+        node_id = _find_symbol_node_id(model, item_name, item_filepath)
+        if node_id and model.get_node(node_id) is not None:
+            results = []
+            # Get CALLS + MONITORS incoming edges
+            for edge_type in (SemanticEdgeType.CALLS, SemanticEdgeType.MONITORS):
+                for _, src_id in model.get_incoming(node_id, edge_type):
+                    item = _node_to_call_hierarchy_item(model, src_id)
+                    if item is None:
+                        continue
+                    # Targeted regex for from_ranges (just the caller's body)
+                    from_ranges = _targeted_from_ranges(
+                        item.name, item_name, item_filepath, indexer
+                    )
+                    results.append(
+                        lsp.CallHierarchyIncomingCall(
+                            from_=item,
+                            from_ranges=from_ranges or [item.range],
+                        )
+                    )
+            if results:
+                return results
+
+    # Fallback: regex scanning (existing implementation)
+    return _get_incoming_calls_regex(indexer, item_name, item_filepath)
+```
+
+Rename the existing `get_incoming_calls` body to `_get_incoming_calls_regex`.
+
+- [ ] **Step 5: Add `_targeted_from_ranges()` helper**
+
+```python
+def _targeted_from_ranges(
+    caller_name: str,
+    target_name: str,
+    target_filepath: str,
+    indexer,
+) -> List[lsp.Range]:
+    """Find exact ranges where *target_name* appears in *caller_name*'s body."""
+    last_component = target_name.rsplit(".", 1)[-1] if "." in target_name else target_name
+    pattern = re.compile(r"\b" + re.escape(last_component) + r"\b")
+
+    # Find caller's file and body
+    results = indexer.lookup_symbol(caller_name) if indexer else []
+    if not results:
+        return []
+
+    sl = results[0]
+    fpath = sl.filepath
+    if not fpath:
+        return []
+
+    try:
+        source = Path(fpath).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    file_lines = source.split("\n")
+    file_symbols = indexer.get_symbols(fpath)
+    decl_line = sl.range[0]
+
+    # Find end of caller's scope
+    sorted_lines = sorted(set(s.range[0] for s in file_symbols))
+    idx = sorted_lines.index(decl_line) if decl_line in sorted_lines else -1
+    if idx >= 0 and idx + 1 < len(sorted_lines):
+        end_line = sorted_lines[idx + 1]
+    else:
+        end_line = len(file_lines)
+
+    ranges = []
+    for line_idx in range(decl_line + 1, min(end_line, len(file_lines))):
+        for match in pattern.finditer(file_lines[line_idx]):
+            ranges.append(make_range(line_idx, match.start(), line_idx, match.end()))
+    return ranges
+```
+
+- [ ] **Step 6: Refactor `get_outgoing_calls()` similarly**
+
+```python
+def get_outgoing_calls(
+    indexer,
+    item_name: str,
+    item_filepath: str,
+    model=None,
+) -> List[lsp.CallHierarchyOutgoingCall]:
+    """Find all actions referenced in the body of *item_name*."""
+    if model is not None:
+        from ivy_lsp.semantic.edges import SemanticEdgeType
+
+        node_id = _find_symbol_node_id(model, item_name, item_filepath)
+        if node_id and model.get_node(node_id) is not None:
+            results = []
+            for _, tgt_id in model.get_outgoing(node_id, SemanticEdgeType.CALLS):
+                item = _node_to_call_hierarchy_item(model, tgt_id)
+                if item is None:
+                    continue
+                from_ranges = _targeted_from_ranges(
+                    item_name, item.name, item_filepath, indexer
+                )
+                results.append(
+                    lsp.CallHierarchyOutgoingCall(
+                        to=item,
+                        from_ranges=from_ranges or [item.range],
+                    )
+                )
+            if results:
+                return results
+
+    return _get_outgoing_calls_regex(indexer, item_name, item_filepath)
+```
+
+Rename the existing `get_outgoing_calls` body to `_get_outgoing_calls_regex`.
+
+- [ ] **Step 7: Update `register()` handlers to pass model**
+
+In the `incoming_calls` handler:
+```python
+return await loop.run_in_executor(
+    None, get_incoming_calls, server.indexer, name, filepath,
+    getattr(server, "semantic_model", None),
+)
+```
+
+In the `outgoing_calls` handler:
+```python
+return await loop.run_in_executor(
+    None, get_outgoing_calls, server.indexer, name, filepath,
+    getattr(server, "semantic_model", None),
+)
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `python -m pytest tests/test_call_hierarchy.py -v && python -m pytest tests/ -x -q`
+Expected: All pass (old tests use `model=None` fallback, new tests use model path)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add ivy_lsp/features/call_hierarchy.py tests/test_call_hierarchy.py
+git commit -m "refactor: call_hierarchy uses semantic CALLS edges with regex fallback"
+```
+
+---
+
+### Task 8: Integration verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `python -m pytest tests/ -x -q`
+Expected: 2191+ tests pass, 0 failures
+
+- [ ] **Step 2: Verify edge counts via MCP tools**
+
+Use `ivy_model_summary` on the QUIC workspace and check for non-zero CALLS/USES/MONITORS/CONTAINS edge counts.
+
+- [ ] **Step 3: Verify impact analysis works**
+
+Use `ivy_query mode=impact symbol=quic_packet_event` — should return CALLS edges instead of the old "not yet implemented" note.
+
+- [ ] **Step 4: Run nct-validate**
+
+Run `/nct-validate` to ensure the QUIC workspace still passes all checks.
+
+- [ ] **Step 5: Final commit if any fixups needed**
+
+```bash
+git add -u
+git commit -m "fix: address integration test issues for USES/CALLS edge analysis"
+```

--- a/docs/superpowers/plans/2026-03-20-lazy-bridge-mcp.md
+++ b/docs/superpowers/plans/2026-03-20-lazy-bridge-mcp.md
@@ -1,0 +1,1143 @@
+# Lazy Bridge MCP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken `mcp-bridge` startup mode with a standalone MCP server that transparently upgrades to bridge mode when the LSP sidecar becomes available.
+
+**Architecture:** The MCP server starts immediately in standalone mode using the offline `.ivy-index/` cache. A background task polls for the LSP sidecar's port file. When detected and validated, tool calls are delegated to the sidecar via an MCP client connection. If the sidecar goes down, the server reverts to local handling transparently.
+
+**Tech Stack:** Python 3.11, FastMCP, mcp library (streamablehttp_client, ClientSession), asyncio, bash
+
+**Spec:** `docs/superpowers/specs/2026-03-20-lazy-bridge-mcp-architecture-design.md`
+
+---
+
+**Path prefixes used throughout this plan:**
+
+- `PLUGIN` = `panther/plugins/services/testers/panther_ivy/submodules/panther-ivy-plugin/plugins/panther-ivy-plugin`
+- `IVY_LSP` = `panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp/ivy_lsp`
+- `IVY_TESTS` = `panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp/tests`
+
+---
+
+### Task 1: Shell Script and Config Cleanup
+
+Remove the `mcp-bridge` mode from the startup flow. This is the minimal change that fixes the immediate startup failure.
+
+**Files:**
+- Modify: `PLUGIN/scripts/start-ivy-server.sh`
+- Modify: `PLUGIN/.mcp.json`
+- Modify: `PLUGIN/scripts/workspace-common.sh` (line 3 comment)
+- Delete: `PLUGIN/scripts/ivy-lsp-wrapper.sh`
+
+- [ ] **Step 1: Change `.mcp.json` from `mcp-bridge` to `mcp`**
+
+In `PLUGIN/.mcp.json`, change the args array:
+
+```json
+{
+  "mcpServers": {
+    "ivy-tools": {
+      "command": "bash",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/start-ivy-server.sh",
+        "--mode",
+        "mcp"
+      ],
+      "env": {
+        "IVY_LSP_LOG_LEVEL": "DEBUG",
+        "IVY_LSP_DEBUG_LOG": "1",
+        "IVY_LSP_MAX_CONCURRENT_TOOLS": "4",
+        "IVY_LSP_FAST_INDEX_WORKERS": "4",
+        "IVY_LSP_PARSE_WORKERS": "1",
+        "IVY_LSP_BULK_WORKERS": "4",
+        "IVY_LSP_COMPILE_WORKERS": "2",
+        "IVY_LSP_PREWARM_MODEL": "1",
+        "IVY_LSP_PREWARM_GRAPH": "1"
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Remove `mcp-bridge` from `start-ivy-server.sh`**
+
+Three changes in `PLUGIN/scripts/start-ivy-server.sh`:
+
+**(a)** Line 22 — remove `mcp-bridge` from validation:
+```bash
+# Before:
+if [[ "$MODE" != "lsp" && "$MODE" != "mcp" && "$MODE" != "mcp-bridge" ]]; then
+# After:
+if [[ "$MODE" != "lsp" && "$MODE" != "mcp" ]]; then
+```
+
+**(b)** Lines 29-33 — remove the deprecation notice:
+```bash
+# DELETE these lines:
+if [ "$MODE" = "mcp" ]; then
+    echo "[ivy-mcp] NOTE: Standalone MCP mode is deprecated..." >&2
+    echo "[ivy-mcp] served by the LSP process via HTTP sidecar..." >&2
+    echo "[ivy-mcp] This mode is kept for backward compatibility." >&2
+fi
+```
+
+**(c)** Lines 92-135 — remove the entire `mcp-bridge` block:
+```bash
+# DELETE from:
+# --- mcp-bridge: wait for sidecar, then relay stdio↔HTTP ---
+if [ "$MODE" = "mcp-bridge" ]; then
+    ...
+fi
+# DELETE to the end of the `fi` at line 135.
+```
+
+- [ ] **Step 3: Update `workspace-common.sh` comment**
+
+In `PLUGIN/scripts/workspace-common.sh` line 3, update the comment:
+```bash
+# Before:
+# Sourced by start-ivy-tools.sh, ivy-lsp-wrapper.sh, and detect-ivy-workspace.sh.
+# After:
+# Sourced by start-ivy-server.sh.
+```
+
+- [ ] **Step 4: Delete `ivy-lsp-wrapper.sh`**
+
+```bash
+rm PLUGIN/scripts/ivy-lsp-wrapper.sh
+```
+
+Verify no other files reference it (confirmed: only the comment updated in step 3).
+
+- [ ] **Step 5: Verify shell script syntax**
+
+```bash
+bash -n PLUGIN/scripts/start-ivy-server.sh
+```
+
+Expected: no output (clean syntax).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A PLUGIN/scripts/ PLUGIN/.mcp.json
+git commit -m "fix: switch MCP from mcp-bridge to standalone mode
+
+Remove the mcp-bridge startup mode that caused a race condition
+with the lazily-started LSP sidecar. MCP now starts immediately
+in standalone mode using the offline index."
+```
+
+---
+
+### Task 2: Add `workspace_root` to Sidecar Health Endpoint
+
+The `/health` endpoint on the MCP HTTP sidecar must return `workspace_root` so the standalone MCP can validate it's connecting to the right sidecar (not one from a different worktree session).
+
+**Files:**
+- Modify: `IVY_LSP/mcp_sidecar.py`
+- Test: `IVY_TESTS/test_mcp_sidecar_health.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `IVY_TESTS/test_mcp_sidecar_health.py`:
+
+```python
+"""Tests for the MCP sidecar /health endpoint."""
+
+import json
+
+
+def test_health_response_includes_workspace_root():
+    """The /health endpoint must return workspace_root for validation."""
+    from ivy_lsp.mcp_sidecar import _health_middleware_factory
+
+    # Create a mock context with a known workspace root
+    class MockCtx:
+        root = "/tmp/test-workspace"
+        def get_model_status(self):
+            return {"state": "ready"}
+
+    middleware = _health_middleware_factory(MockCtx(), start_time=0.0)
+
+    # Simulate an ASGI /health request
+    import asyncio
+
+    scope = {"type": "http", "path": "/health"}
+    response_started = {}
+    response_body = b""
+
+    async def receive():
+        return {"type": "http.request", "body": b""}
+
+    async def send(message):
+        nonlocal response_body
+        if message["type"] == "http.response.start":
+            response_started.update(message)
+        elif message["type"] == "http.response.body":
+            response_body = message.get("body", b"")
+
+    asyncio.get_event_loop().run_until_complete(
+        middleware(scope, receive, send)
+    )
+
+    body = json.loads(response_body)
+    assert body["status"] == "ok"
+    assert body["workspace_root"] == "/tmp/test-workspace"
+    assert "uptime_seconds" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_mcp_sidecar_health.py -v
+```
+
+Expected: FAIL — `_health_middleware_factory` does not exist yet.
+
+- [ ] **Step 3: Refactor `/health` handler into a testable factory**
+
+In `IVY_LSP/mcp_sidecar.py`, extract the inline `_health_middleware` into a factory function. The current code (inside `_serve_mcp_http`) defines the middleware as a closure. Refactor to:
+
+```python
+def _health_middleware_factory(ctx: Any, start_time: float):
+    """Create an ASGI middleware that intercepts /health requests.
+
+    Args:
+        ctx: ToolContext with workspace info and model status.
+        start_time: monotonic timestamp of sidecar start for uptime calc.
+
+    Returns:
+        An ASGI middleware callable.
+    """
+    import time as _time_mod
+
+    async def _health_middleware(scope: dict, receive: Any, send: Any) -> None:
+        if scope["type"] == "http" and scope["path"] == "/health":
+            model_status = "unknown"
+            if ctx is not None and hasattr(ctx, "get_model_status"):
+                try:
+                    model_status = ctx.get_model_status().get("state", "unknown")
+                except Exception:
+                    model_status = "error"
+
+            body = _json.dumps(
+                {
+                    "status": "ok",
+                    "uptime_seconds": round(_time_mod.monotonic() - start_time, 1),
+                    "tools_registered": 13,
+                    "model_status": model_status,
+                    "workspace_root": getattr(ctx, "root", ""),
+                }
+            ).encode()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [[b"content-type", b"application/json"]],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+        # Non-health requests pass through to the MCP ASGI app
+        # (not available in test context — tests only hit /health)
+    return _health_middleware
+```
+
+Then update `_serve_mcp_http` to use it:
+```python
+async def _serve_mcp_http(mcp_app, port, workspace_root, ctx=None):
+    # ... (uvicorn import, asgi_app setup) ...
+    sidecar_start_time = _time.monotonic()
+    health_mw = _health_middleware_factory(ctx, sidecar_start_time)
+
+    async def _wrapped_app(scope, receive, send):
+        if scope["type"] == "http" and scope["path"] == "/health":
+            return await health_mw(scope, receive, send)
+        return await asgi_app(scope, receive, send)
+    # ... use _wrapped_app in uvicorn config ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_mcp_sidecar_health.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+git add ivy_lsp/mcp_sidecar.py tests/test_mcp_sidecar_health.py
+git commit -m "feat: add workspace_root to sidecar /health response
+
+The lazy bridge MCP monitor needs to validate that a sidecar
+belongs to the same workspace before upgrading. The /health
+endpoint now includes workspace_root in its response JSON."
+```
+
+---
+
+### Task 3: Sidecar Client Module
+
+Create a new module that handles connecting to the sidecar, validating workspace, and delegating tool calls. This isolates all sidecar communication logic.
+
+**Files:**
+- Create: `IVY_LSP/sidecar_client.py`
+- Test: `IVY_TESTS/test_sidecar_client.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `IVY_TESTS/test_sidecar_client.py`:
+
+```python
+"""Tests for the sidecar client — connection, validation, delegation."""
+
+import asyncio
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def test_read_port_file_returns_port(tmp_path):
+    """Read a valid port file."""
+    from ivy_lsp.sidecar_client import read_port_file
+
+    port_file = tmp_path / "ivy-mcp-abc123.port"
+    port_file.write_text("19847")
+    assert read_port_file(str(tmp_path), "abc123") == 19847
+
+
+def test_read_port_file_returns_none_when_missing(tmp_path):
+    """Missing port file returns None."""
+    from ivy_lsp.sidecar_client import read_port_file
+
+    assert read_port_file(str(tmp_path), "abc123") is None
+
+
+def test_read_port_file_returns_none_when_corrupt(tmp_path):
+    """Corrupt port file returns None."""
+    from ivy_lsp.sidecar_client import read_port_file
+
+    port_file = tmp_path / "ivy-mcp-abc123.port"
+    port_file.write_text("not-a-number")
+    assert read_port_file(str(tmp_path), "abc123") is None
+
+
+def test_workspace_hash_is_stable():
+    """Same path always produces the same hash."""
+    from ivy_lsp.sidecar_client import workspace_hash
+
+    h1 = workspace_hash("/some/path")
+    h2 = workspace_hash("/some/path")
+    assert h1 == h2
+    assert len(h1) == 12
+
+
+def test_workspace_hash_differs_for_different_paths():
+    """Different paths produce different hashes."""
+    from ivy_lsp.sidecar_client import workspace_hash
+
+    assert workspace_hash("/path/a") != workspace_hash("/path/b")
+
+
+@pytest.mark.asyncio
+async def test_validate_workspace_rejects_mismatch():
+    """Validation rejects a sidecar with a different workspace root."""
+    from ivy_lsp.sidecar_client import validate_sidecar_workspace
+
+    with patch("ivy_lsp.sidecar_client._fetch_health") as mock_fetch:
+        mock_fetch.return_value = {"workspace_root": "/other/workspace"}
+        result = await validate_sidecar_workspace(19847, "/my/workspace")
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_validate_workspace_accepts_match():
+    """Validation accepts a sidecar with matching workspace root."""
+    from ivy_lsp.sidecar_client import validate_sidecar_workspace
+
+    with patch("ivy_lsp.sidecar_client._fetch_health") as mock_fetch:
+        mock_fetch.return_value = {"workspace_root": "/my/workspace"}
+        result = await validate_sidecar_workspace(19847, "/my/workspace")
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_validate_workspace_handles_unreachable():
+    """Validation returns False if health endpoint is unreachable."""
+    from ivy_lsp.sidecar_client import validate_sidecar_workspace
+
+    with patch("ivy_lsp.sidecar_client._fetch_health") as mock_fetch:
+        mock_fetch.return_value = None
+        result = await validate_sidecar_workspace(19847, "/my/workspace")
+        assert result is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_sidecar_client.py -v
+```
+
+Expected: FAIL — `ivy_lsp.sidecar_client` module does not exist.
+
+- [ ] **Step 3: Implement `sidecar_client.py`**
+
+Create `IVY_LSP/sidecar_client.py`:
+
+**NOTE:** Uses `urllib.request` (stdlib, already used in `ivy_lsp/rfc/fetcher.py`) instead of `aiohttp` (not a dependency). Health checks run in a thread via `asyncio.to_thread()`. This module also owns the `_sidecar_client` global state to avoid circular imports between `mcp_server.py` and `tools/__init__.py`.
+
+```python
+"""Sidecar client for the lazy bridge upgrade mechanism.
+
+Handles:
+- Global sidecar client state (get/set)
+- Port file reading and workspace hash computation
+- Sidecar health check and workspace validation
+- MCP client connection via streamablehttp_client
+
+This module is imported by both mcp_server.py (monitor) and
+tools/__init__.py (safe_tool delegation). It must NOT import
+from either to avoid circular imports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# --- Global sidecar client state ---
+# Owned here to avoid circular imports between mcp_server and tools.
+_sidecar_client: Any | None = None
+
+
+def get_sidecar_client() -> Any | None:
+    """Read the current sidecar client. Used by safe_tool."""
+    return _sidecar_client
+
+
+def set_sidecar_client(client: Any | None) -> None:
+    """Swap the sidecar client reference (atomic under CPython GIL)."""
+    global _sidecar_client
+    _sidecar_client = client
+
+
+def workspace_hash(root: str) -> str:
+    """Stable 12-char hash of the workspace root path."""
+    return hashlib.sha256(root.encode()).hexdigest()[:12]
+
+
+def read_port_file(
+    port_dir: str = "/tmp", ws_hash: str | None = None
+) -> int | None:
+    """Read the sidecar port from /tmp/ivy-mcp-{ws_hash}.port.
+
+    Returns the port number, or None if missing/corrupt.
+    """
+    if ws_hash is None:
+        return None
+    path = os.path.join(port_dir, f"ivy-mcp-{ws_hash}.port")
+    try:
+        with open(path) as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _fetch_health_sync(port: int) -> dict | None:
+    """Fetch sidecar /health (synchronous, for use via asyncio.to_thread)."""
+    url = f"http://127.0.0.1:{port}/health"
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            if resp.status == 200:
+                return json.loads(resp.read().decode())
+    except Exception:
+        logger.debug("Sidecar health check failed on port %d", port)
+    return None
+
+
+async def _fetch_health(port: int) -> dict | None:
+    """Async wrapper around the synchronous health check."""
+    return await asyncio.to_thread(_fetch_health_sync, port)
+
+
+async def validate_sidecar_workspace(
+    port: int, expected_root: str
+) -> bool:
+    """Check that the sidecar's workspace_root matches ours.
+
+    Prevents upgrading to a sidecar from a different worktree session.
+    """
+    health = await _fetch_health(port)
+    if health is None:
+        return False
+    sidecar_root = health.get("workspace_root", "")
+    if not sidecar_root:
+        logger.debug("Sidecar /health missing workspace_root")
+        return False
+    match = os.path.realpath(sidecar_root) == os.path.realpath(expected_root)
+    if not match:
+        logger.debug(
+            "Workspace mismatch: ours=%s sidecar=%s", expected_root, sidecar_root
+        )
+    return match
+
+
+async def connect_to_sidecar(port: int) -> Any:
+    """Establish an MCP client session to the sidecar.
+
+    Returns a ClientSession that can call tools, or None on failure.
+    Stores the transport context manager on the session object
+    as `_transport_ctx` for cleanup on disconnect.
+    """
+    try:
+        from mcp.client.streamable_http import streamablehttp_client
+        from mcp import ClientSession
+
+        url = f"http://127.0.0.1:{port}/mcp"
+        transport_ctx = streamablehttp_client(url)
+        read_stream, write_stream, _ = await transport_ctx.__aenter__()
+
+        session = ClientSession(read_stream, write_stream)
+        await session.__aenter__()
+        await session.initialize()
+
+        # Stash transport context for cleanup
+        session._transport_ctx = transport_ctx
+        logger.info("[SIDECAR-CLIENT] Connected to sidecar on port %d", port)
+        return session
+    except Exception:
+        logger.warning("[SIDECAR-CLIENT] Failed to connect to port %d", port, exc_info=True)
+        return None
+
+
+async def disconnect_sidecar(session: Any) -> None:
+    """Clean up an MCP client session and its transport."""
+    try:
+        await session.__aexit__(None, None, None)
+    except Exception:
+        logger.debug("Session cleanup failed", exc_info=True)
+    try:
+        ctx = getattr(session, "_transport_ctx", None)
+        if ctx is not None:
+            await ctx.__aexit__(None, None, None)
+    except Exception:
+        logger.debug("Transport cleanup failed", exc_info=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_sidecar_client.py -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+git add ivy_lsp/sidecar_client.py tests/test_sidecar_client.py
+git commit -m "feat: add sidecar client for lazy bridge upgrade
+
+New module handling port file reading, workspace validation,
+and MCP client connection to the LSP sidecar. Used by the
+sidecar monitor and safe_tool delegation."
+```
+
+---
+
+### Task 4: Sidecar Monitor Background Task
+
+Add the background task to `mcp_server.py` that polls for the sidecar port file and triggers the upgrade.
+
+**Files:**
+- Modify: `IVY_LSP/mcp_server.py`
+- Test: `IVY_TESTS/test_sidecar_monitor.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `IVY_TESTS/test_sidecar_monitor.py`:
+
+```python
+"""Tests for the sidecar monitor background task."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from ivy_lsp import sidecar_client
+
+
+@pytest.mark.asyncio
+async def test_monitor_skips_when_disabled():
+    """Monitor exits immediately when IVY_MCP_DISABLE_UPGRADE=1."""
+    from ivy_lsp.mcp_server import _sidecar_monitor
+
+    with patch.dict("os.environ", {"IVY_MCP_DISABLE_UPGRADE": "1"}):
+        # Should return without polling
+        task = asyncio.create_task(_sidecar_monitor("/workspace"))
+        await asyncio.sleep(0.1)
+        assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_monitor_sets_client_on_valid_sidecar():
+    """Monitor sets sidecar_client when sidecar is validated."""
+    from ivy_lsp.mcp_server import _sidecar_monitor
+
+    mock_client = MagicMock()
+
+    old = sidecar_client.get_sidecar_client()
+    try:
+        sidecar_client.set_sidecar_client(None)
+
+        with patch("ivy_lsp.mcp_server.sidecar_client") as mock_sc:
+            mock_sc.workspace_hash.return_value = "abc123"
+            mock_sc.read_port_file.return_value = 19847
+            mock_sc.validate_sidecar_workspace = AsyncMock(return_value=True)
+            mock_sc.connect_to_sidecar = AsyncMock(return_value=mock_client)
+            mock_sc.get_sidecar_client.return_value = None
+            mock_sc.set_sidecar_client = sidecar_client.set_sidecar_client
+
+            task = asyncio.create_task(
+                _sidecar_monitor("/workspace", _poll_interval=0.05, _max_iterations=2)
+            )
+            await asyncio.sleep(0.2)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert sidecar_client.get_sidecar_client() is mock_client
+    finally:
+        sidecar_client.set_sidecar_client(old)
+
+
+@pytest.mark.asyncio
+async def test_monitor_skips_workspace_mismatch():
+    """Monitor does not upgrade when workspace doesn't match."""
+    from ivy_lsp.mcp_server import _sidecar_monitor
+
+    old = sidecar_client.get_sidecar_client()
+    try:
+        sidecar_client.set_sidecar_client(None)
+
+        with patch("ivy_lsp.mcp_server.sidecar_client") as mock_sc:
+            mock_sc.workspace_hash.return_value = "abc123"
+            mock_sc.read_port_file.return_value = 19847
+            mock_sc.validate_sidecar_workspace = AsyncMock(return_value=False)
+            mock_sc.get_sidecar_client.return_value = None
+
+            task = asyncio.create_task(
+                _sidecar_monitor("/workspace", _poll_interval=0.05, _max_iterations=2)
+            )
+            await asyncio.sleep(0.2)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert sidecar_client.get_sidecar_client() is None
+    finally:
+        sidecar_client.set_sidecar_client(old)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_sidecar_monitor.py -v
+```
+
+Expected: FAIL — `_sidecar_monitor` does not exist.
+
+- [ ] **Step 3: Add sidecar monitor to `mcp_server.py`**
+
+Add near the top of `IVY_LSP/mcp_server.py` (after existing imports):
+
+```python
+from ivy_lsp import sidecar_client
+```
+
+Then add the monitor function (can go after the `ToolContext` class):
+
+```python
+async def _sidecar_monitor(
+    workspace_root: str,
+    _poll_interval: float = 2.0,
+    _max_iterations: int = 0,
+) -> None:
+    """Background task: poll for sidecar port file, upgrade when ready.
+
+    Args:
+        workspace_root: Our workspace root for validation.
+        _poll_interval: Override for testing (default 2s).
+        _max_iterations: If >0, exit after N iterations (for testing).
+    """
+    if os.environ.get("IVY_MCP_DISABLE_UPGRADE") == "1":
+        logger.info("[SIDECAR-MONITOR] Upgrade disabled by IVY_MCP_DISABLE_UPGRADE")
+        return
+
+    ws_hash = sidecar_client.workspace_hash(workspace_root)
+    elapsed = 0.0
+    poll = _poll_interval
+    iteration = 0
+
+    while True:
+        await asyncio.sleep(poll)
+        elapsed += poll
+        iteration += 1
+
+        if _max_iterations > 0 and iteration >= _max_iterations:
+            return
+
+        # Progressive backoff: fast for first 60s, then slow
+        if elapsed > 60 and poll < 10:
+            poll = 10.0
+            logger.debug("[SIDECAR-MONITOR] Backing off to 10s polling")
+
+        # Already upgraded — just keep a slow heartbeat
+        if sidecar_client.get_sidecar_client() is not None:
+            poll = 30.0
+            continue
+
+        port = sidecar_client.read_port_file(ws_hash=ws_hash)
+        if port is None:
+            continue
+
+        if not await sidecar_client.validate_sidecar_workspace(port, workspace_root):
+            logger.debug("[SIDECAR-MONITOR] Workspace mismatch, skipping")
+            continue
+
+        client = await sidecar_client.connect_to_sidecar(port)
+        if client is not None:
+            sidecar_client.set_sidecar_client(client)
+            logger.info("[UPGRADED] Delegating tools to LSP sidecar on port %d", port)
+            poll = 30.0
+```
+
+Then in `start_mcp()`, launch the monitor **after** the MCP app is created but **before** calling `mcp.run()`. FastMCP's `run()` starts its own event loop, so use the `startup` hook or register the monitor as a coroutine that runs alongside the server. The simplest integration:
+
+```python
+# In start_mcp(), just before mcp.run():
+import threading
+
+def _start_monitor_in_thread():
+    """Run the sidecar monitor in its own event loop (daemon thread)."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(_sidecar_monitor(root))
+
+if os.environ.get("IVY_MCP_DISABLE_UPGRADE") != "1":
+    monitor_thread = threading.Thread(
+        target=_start_monitor_in_thread,
+        name="sidecar-monitor",
+        daemon=True,
+    )
+    monitor_thread.start()
+    logger.info("[SIDECAR-MONITOR] Started background upgrade monitor")
+```
+
+**Note:** The monitor runs in a daemon thread with its own event loop because FastMCP's `run()` blocks the main thread's event loop. The sidecar client state (`_sidecar_client`) is accessed atomically via the GIL.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_sidecar_monitor.py -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+git add ivy_lsp/mcp_server.py tests/test_sidecar_monitor.py
+git commit -m "feat: add sidecar monitor background task
+
+Polls for the LSP sidecar port file with progressive backoff
+(2s initially, 10s after 60s). When detected and validated,
+sets _sidecar_client for tool delegation. Supports
+IVY_MCP_DISABLE_UPGRADE=1 to skip monitoring."
+```
+
+---
+
+### Task 5: `safe_tool` Sidecar Delegation
+
+Modify the `safe_tool` decorator to delegate tool calls to the sidecar when `_sidecar_client` is set.
+
+**Files:**
+- Modify: `IVY_LSP/tools/__init__.py`
+- Test: `IVY_TESTS/test_safe_tool_delegation.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `IVY_TESTS/test_safe_tool_delegation.py`:
+
+**Note:** Tests patch `ivy_lsp.sidecar_client` (where the state lives), not `ivy_lsp.tools` (which re-exports). The `safe_tool` decorator rebuilds the wrapper with `fn.__globals__`, so tests must ensure `get_sidecar_client` and `set_sidecar_client` are in those globals. We test delegation in isolation by calling `get_sidecar_client` directly and verifying behavior, rather than decorating test functions with `safe_tool` (which requires the full config/logging stack).
+
+```python
+"""Tests for safe_tool sidecar delegation."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ivy_lsp import sidecar_client
+
+
+@pytest.mark.asyncio
+async def test_delegation_calls_sidecar_when_client_set():
+    """When _sidecar_client is set, get_sidecar_client returns it."""
+    mock_client = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.content = [MagicMock(text='{"delegated": true}')]
+    mock_client.call_tool.return_value = mock_result
+
+    old = sidecar_client.get_sidecar_client()
+    try:
+        sidecar_client.set_sidecar_client(mock_client)
+        client = sidecar_client.get_sidecar_client()
+        assert client is mock_client
+
+        # Simulate what safe_tool does
+        result = await client.call_tool("ivy_capabilities", {})
+        mock_client.call_tool.assert_called_once_with("ivy_capabilities", {})
+    finally:
+        sidecar_client.set_sidecar_client(old)
+
+
+@pytest.mark.asyncio
+async def test_delegation_resets_client_on_error():
+    """On connection error, set_sidecar_client(None) reverts to local."""
+    mock_client = AsyncMock()
+    mock_client.call_tool.side_effect = ConnectionError("sidecar gone")
+
+    old = sidecar_client.get_sidecar_client()
+    try:
+        sidecar_client.set_sidecar_client(mock_client)
+
+        # Simulate safe_tool error path
+        try:
+            await mock_client.call_tool("ivy_capabilities", {})
+        except ConnectionError:
+            sidecar_client.set_sidecar_client(None)
+
+        assert sidecar_client.get_sidecar_client() is None
+    finally:
+        sidecar_client.set_sidecar_client(old)
+
+
+def test_no_client_returns_none():
+    """When no sidecar is set, get_sidecar_client returns None."""
+    old = sidecar_client.get_sidecar_client()
+    try:
+        sidecar_client.set_sidecar_client(None)
+        assert sidecar_client.get_sidecar_client() is None
+    finally:
+        sidecar_client.set_sidecar_client(old)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_safe_tool_delegation.py -v
+```
+
+Expected: FAIL — `get_sidecar_client` not imported in tools.
+
+- [ ] **Step 3: Add delegation to `safe_tool` in `tools/__init__.py`**
+
+At the top of `IVY_LSP/tools/__init__.py`, add import:
+
+```python
+from ivy_lsp.sidecar_client import get_sidecar_client, set_sidecar_client
+```
+
+**Note:** Imports from `sidecar_client` (NOT `mcp_server`) to avoid circular imports. `mcp_server.py` imports from `tools/__init__.py` via `register_all_tools`, so importing back from `mcp_server` would create a cycle.
+
+Then in the `safe_tool` function, add the delegation check at the very beginning of `_wrapper`, **before** the semaphore acquire and timeout:
+
+```python
+def safe_tool(fn):
+    @functools.wraps(fn)
+    async def _wrapper(*args, **kwargs):
+        # --- Sidecar delegation (lazy bridge) ---
+        # Check BEFORE semaphore/timeout — sidecar handles its own concurrency
+        _client = get_sidecar_client()
+        if _client is not None:
+            try:
+                result = await _client.call_tool(fn.__name__, kwargs)
+                return result  # verbatim from sidecar, no local formatting
+            except Exception:
+                logger.warning(
+                    "[DOWNGRADED] Sidecar call to %s failed, using local",
+                    fn.__name__,
+                )
+                set_sidecar_client(None)
+                # Fall through to local handling
+
+        # --- Original local handling below (unchanged) ---
+        from ivy_lsp.config import get_config
+        # ... (rest of existing _wrapper code) ...
+```
+
+**Critical:** Add `get_sidecar_client` and `set_sidecar_client` to the `_injected_names` dict (around line 430) so they are available in the rebuilt `FunctionType` wrapper:
+
+```python
+    _injected_names = {
+        # ... existing entries ...
+        "get_sidecar_client": get_sidecar_client,
+        "set_sidecar_client": set_sidecar_client,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_safe_tool_delegation.py -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run existing tool tests to ensure no regression**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_tools_verification.py tests/test_tools_analysis.py tests/test_tools_quality.py tests/test_tools_patterns.py tests/test_tools_traceability.py -v --timeout=60
+```
+
+Expected: All existing tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+git add ivy_lsp/tools/__init__.py tests/test_safe_tool_delegation.py
+git commit -m "feat: add sidecar delegation to safe_tool decorator
+
+When _sidecar_client is set by the sidecar monitor, tool calls
+are forwarded to the LSP sidecar via MCP client. Sidecar response
+is returned verbatim (no local formatting/timeout). Falls back to
+local handling on connection errors with [DOWNGRADED] log."
+```
+
+---
+
+### Task 6: Integration Test — Upgrade/Downgrade Cycle
+
+End-to-end test that simulates the full lifecycle: standalone start → sidecar appears → upgrade → sidecar dies → downgrade.
+
+**Files:**
+- Test: `IVY_TESTS/test_lazy_bridge_integration.py`
+
+- [ ] **Step 1: Write integration test**
+
+Create `IVY_TESTS/test_lazy_bridge_integration.py`:
+
+```python
+"""Integration test for the lazy bridge lifecycle.
+
+Tests the full cycle:
+1. MCP starts standalone (no sidecar)
+2. Sidecar port file appears
+3. Monitor detects and upgrades
+4. Tool calls are delegated
+5. Sidecar goes away
+6. Tool calls revert to local
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ivy_lsp import sidecar_client
+
+
+@pytest.mark.asyncio
+async def test_full_upgrade_downgrade_cycle():
+    """Simulate: standalone → upgrade → downgrade → standalone."""
+    from ivy_lsp.mcp_server import _sidecar_monitor
+
+    old = sidecar_client.get_sidecar_client()
+    try:
+        # Start clean
+        sidecar_client.set_sidecar_client(None)
+        assert sidecar_client.get_sidecar_client() is None
+
+        mock_client = AsyncMock()
+
+        # Phase 1: No port file → stays standalone
+        with patch("ivy_lsp.mcp_server.sidecar_client") as mock_sc:
+            mock_sc.workspace_hash.return_value = "test123"
+            mock_sc.read_port_file.return_value = None
+            mock_sc.get_sidecar_client = sidecar_client.get_sidecar_client
+
+            task = asyncio.create_task(
+                _sidecar_monitor("/workspace", _poll_interval=0.05, _max_iterations=2)
+            )
+            await asyncio.sleep(0.2)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert sidecar_client.get_sidecar_client() is None  # Still standalone
+
+        # Phase 2: Port file appears → upgrade
+        with patch("ivy_lsp.mcp_server.sidecar_client") as mock_sc:
+            mock_sc.workspace_hash.return_value = "test123"
+            mock_sc.read_port_file.return_value = 19847
+            mock_sc.validate_sidecar_workspace = AsyncMock(return_value=True)
+            mock_sc.connect_to_sidecar = AsyncMock(return_value=mock_client)
+            mock_sc.get_sidecar_client.return_value = None
+            mock_sc.set_sidecar_client = sidecar_client.set_sidecar_client
+
+            task = asyncio.create_task(
+                _sidecar_monitor("/workspace", _poll_interval=0.05, _max_iterations=2)
+            )
+            await asyncio.sleep(0.2)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert sidecar_client.get_sidecar_client() is mock_client  # Upgraded!
+
+        # Phase 3: Downgrade
+        sidecar_client.set_sidecar_client(None)
+        assert sidecar_client.get_sidecar_client() is None  # Back to standalone
+    finally:
+        sidecar_client.set_sidecar_client(old)
+
+
+@pytest.mark.asyncio
+async def test_disable_upgrade_env_var():
+    """IVY_MCP_DISABLE_UPGRADE=1 prevents monitor from running."""
+    from ivy_lsp.mcp_server import _sidecar_monitor
+
+    old = sidecar_client.get_sidecar_client()
+    try:
+        sidecar_client.set_sidecar_client(None)
+
+        with patch.dict(os.environ, {"IVY_MCP_DISABLE_UPGRADE": "1"}):
+            await _sidecar_monitor("/workspace")
+
+        assert sidecar_client.get_sidecar_client() is None
+    finally:
+        sidecar_client.set_sidecar_client(old)
+```
+
+- [ ] **Step 2: Run integration test**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/test_lazy_bridge_integration.py -v
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 3: Run full test suite to check for regressions**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+python -m pytest tests/ -v --timeout=120 -x -q 2>&1 | tail -20
+```
+
+Expected: No new failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd panther/plugins/services/testers/panther_ivy/submodules/ivy-lsp
+git add tests/test_lazy_bridge_integration.py
+git commit -m "test: add integration test for lazy bridge lifecycle
+
+Covers standalone start, sidecar detection → upgrade,
+sidecar loss → downgrade, and IVY_MCP_DISABLE_UPGRADE env var."
+```
+
+---
+
+### Task 7: Manual Validation
+
+Verify the changes work end-to-end in a real Claude Code session.
+
+**Files:** None (manual testing only)
+
+- [ ] **Step 1: Update the panther_ivy submodule pointer**
+
+```bash
+cd /path/to/panther/root
+git add panther/plugins/services/testers/panther_ivy
+git commit -m "chore: update panther_ivy submodule (lazy bridge MCP)"
+```
+
+- [ ] **Step 2: Start a fresh Claude Code session**
+
+Open a new Claude Code session in the same worktree.
+
+- [ ] **Step 3: Run `/nct-health`**
+
+Expected:
+- Step 1 (LSP alive): PASS or WARN (on-demand)
+- Step 4 (MCP alive): **PASS** (was FAIL before)
+- Step 5 (Workspace access): **PASS** (was FAIL before)
+- Step 6 (Model builds): **PASS** (was FAIL before)
+
+- [ ] **Step 4: Check MCP log for standalone start**
+
+```bash
+tail -30 /tmp/ivy-mcp-latest.log
+```
+
+Expected: `[MCP-READY]` log line, no `mcp-bridge` references.
+
+- [ ] **Step 5: Open an `.ivy` file to trigger LSP + sidecar**
+
+Open any `.ivy` file (e.g., via `Read` or `LSP` tool call). Wait 10 seconds.
+
+```bash
+tail -5 /tmp/ivy-mcp-latest.log
+```
+
+Expected: `[UPGRADED] Delegating tools to LSP sidecar on port NNNNN`
+
+- [ ] **Step 6: Verify stale PID cleanup**
+
+```bash
+ls /tmp/ivy-lsp-pids/
+```
+
+Expected: Only active PID files, no stale entries from previous sessions.

--- a/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
+++ b/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
@@ -14,7 +14,7 @@
 
 | Capability | Ivy LSP | TLA+ (VS Code ext) | SPIN/Promela | Tamarin (VS Code ext) | ProVerif (vscode-proverif) |
 |---|---|---|---|---|---|
-| **LSP server** | Full (pygls, 17 registered features) | Shipping (SANY-based VS Code ext); TLAPM proof LSP in development | None | None (tree-sitter grammar; interactive web prover provides exploration) | Partial (syntax + parse errors + signatures) |
+| **LSP server** | Full (pygls, 19 registered features) | Shipping (SANY-based VS Code ext); TLAPM proof LSP in development | None | None (tree-sitter grammar; interactive web prover provides exploration) | Partial (syntax + parse errors + signatures) |
 | **Go-to-definition** | Cross-file + include resolution | Yes | No | No | Yes (Ctrl+click) |
 | **Find references** | Workspace-wide | Yes | No | No | Yes |
 | **Completions** | Context-aware (dot-access, includes, keywords, semantic) | Basic (keywords + identifiers) | No | No | No |
@@ -27,7 +27,7 @@
 | **Selection range** | Yes (smart expansion) | No | No | No | No |
 | **Signature help** | Action parameter hints | No | No | No | Yes |
 
-**Verdict**: Ivy LSP is the **most feature-complete language server** among all protocol verification tools (17 registered feature handlers). TLA+'s shipping VS Code extension provides go-to-definition, find-refs, and SANY diagnostics, but lacks completions, code lens, and code actions. ProVerif's extension provides syntax and parse error reporting but is not a full LSP. SPIN and Tamarin have no LSP (Tamarin's web prover offers interactive exploration outside the LSP protocol).
+**Verdict**: Ivy LSP is the **most feature-complete language server** among all protocol verification tools (19 registered feature handlers). TLA+'s shipping VS Code extension provides go-to-definition, find-refs, and SANY diagnostics, but lacks completions, code lens, and code actions. ProVerif's extension provides syntax and parse error reporting but is not a full LSP. SPIN and Tamarin have no LSP (Tamarin's web prover offers interactive exploration outside the LSP protocol).
 
 ### 1.2 Verification Integration
 
@@ -64,7 +64,7 @@
 | Capability | Ivy MCP+Plugin | TLA+ (MCP, 2025) | Quint (MCP) | Alloy (MCP) |
 |---|---|---|---|---|
 | **MCP tools** | 15 unified tools (verification, analysis, traceability, visualization, patterns, quality) | SANY parsing + TLC model checking | Type-check + simulate + model-check | Model generation + analysis |
-| **Specification scaffolding** | Pattern library (6 patterns) + 14-layer template + `ivy_pattern_scaffold` | None | None | None |
+| **Specification scaffolding** | Pattern library (7 patterns) + 14-layer template + `ivy_pattern_scaffold` | None | None | None |
 | **Quality gates** | 3-tier (minimal/standard/comprehensive) via `ivy_quality(mode="gate")` | None | None | None |
 | **Workflow guidance** | 6 skills + 4 agents with methodology knowledge | None | None | None |
 | **Architecture validation** | `ivy_patterns(mode="check")`: 14-layer completeness scoring | None | None | None |
@@ -108,7 +108,7 @@ After deep import-chain audit (tracing from `server.py` and `mcp_server.py` thro
 - **`formula_analyzer.py`** → Called at `requirement_graph.py:365` via `wire_state_var_edges()`, invoked from `mcp_server.py:694` — extracts state variable references from requirement formulas
 - **`impl_block_parser.py`** → Called at `pattern_library.py:147,358` via `analyze_impl_blocks()`, used by `features/patterns.py:60` and `features/visualization.py:602` — parses implementation blocks for pattern detection
 - **`snapshots.py`** → Used by `compiler_adapter.py:166,262,289-330` — extracts module and signature snapshots from compiler state for Tier 3 enrichment
-- **All 17 LSP features**: Each has a `register()` function called from `server.py` (confirmed by grep across features/)
+- **All 19 LSP features**: Each has a `register()` function called from `server.py` (confirmed by grep across features/)
 - **All 15 MCP tools**: All registered via 6 modules in `tools/__init__.py` → `mcp_server.py`
 - **All 3 CLI tools**: `ivy_check`, `ivyc`, `ivy_show` confirmed available via `ivy_capabilities`
 
@@ -133,7 +133,7 @@ See §1.3. No other formal verification tool integrates this. The system is arch
 
 ### F. Pattern Library + Scaffolding — Unique Differentiator
 - 14-layer canonical decomposition: types → frames → packets → connection → crypto → shim → behavior → monitors → properties → test_specs → application → recovery → extensions → documentation
-- 6 pattern types: serdes, variants, monitors, shims, modules, entities
+- 7 pattern types: serdes, variants, monitors, shims, modules, entities, include-chain
 - Connected chain: `pattern_library.py` → `features/patterns.py` → MCP `ivy_patterns` tool → `ivy_pattern_scaffold` tool
 - Completeness checking: `ivy_patterns(mode="check")` scores against 14-layer template
 - **Files**: `analysis/pattern_library.py`, `analysis/impl_block_parser.py`, `features/patterns.py`, `tools/patterns.py`
@@ -162,8 +162,8 @@ See §1.3. No other formal verification tool integrates this. The system is arch
 
 | Graph | File | Purpose | Size |
 |---|---|---|---|
-| `SemanticModel` | `semantic/model.py` (252 lines) | General-purpose graph: symbols, types, RFC annotations | 4 index structures, 5 query methods |
-| `RequirementGraph` | `analysis/requirement_graph.py` (400+ lines) | Specialized: actions → requirements → state vars | Domain-specific edges (CONSTRAINS, WRITES, COVERS, READS, DEPENDS_ON) |
+| `SemanticModel` | `semantic/model.py` (295 lines) | General-purpose graph: symbols, types, RFC annotations | 4 index structures, 5 query methods |
+| `RequirementGraph` | `analysis/requirement_graph.py` (718 lines) | Specialized: actions → requirements → state vars | Domain-specific edges (CONSTRAINS, WRITES, COVERS, READS, DEPENDS_ON) |
 
 **Evidence of duplication**:
 - Both store requirements as nodes with edges
@@ -178,7 +178,7 @@ See §1.3. No other formal verification tool integrates this. The system is arch
 
 ### B. Analysis Pipeline State Complexity — MEDIUM Priority
 
-**File**: `semantic/analysis_pipeline.py` (874 lines, 37+ public methods)
+**File**: `semantic/analysis_pipeline.py` (896 lines, ~17 methods)
 
 **Problem**: Tier 2 (AST) and Tier 3 (compiler) have overlapping parse+analyze steps with separate thread coordination:
 - `file_generation` OrderedDict tracks per-file generation counts
@@ -189,7 +189,7 @@ See §1.3. No other formal verification tool integrates this. The system is arch
 
 ### C. SemanticModel Over-Indexed — LOW Priority
 
-**File**: `semantic/model.py` (252 lines)
+**File**: `semantic/model.py` (295 lines)
 
 4 index structures maintained eagerly on every `add_node`/`add_edge`:
 - `_edges`: Set[Tuple] for deduplication
@@ -285,7 +285,7 @@ Defines `CompiledModuleIR`, `RequirementIR`, `MixinIR`, `InvariantIR`, etc. Only
 | 1 | Enrich counterexample display formatting in `ivy_verify` results | HIGH | Small | Closes biggest SOTA gap | TLA+/SPIN/Tamarin all have structured counterexample rendering; Ivy has the parser but not the presentation |
 | 2 | Add verification status dashboard (workspace-level summary) | MEDIUM | Medium | Better UX for large specs | Per-isolate cache already has the data; need exposure as tool/view |
 | 3 | Merge RequirementGraph into SemanticModel | MEDIUM | Large | Single source of truth, reduced lock contention | Dual graph is the main remaining over-engineering |
-| 4 | Simplify analysis_pipeline.py Tier 2/3 state management | MEDIUM | Medium | ~30% less coordination code | 874 lines with 37+ methods; Tier 2/3 overlap in parse+analyze |
+| 4 | Simplify analysis_pipeline.py Tier 2/3 state management | MEDIUM | Medium | ~30% less coordination code | 896 lines with ~17 methods; Tier 2/3 overlap in parse+analyze |
 | 5 | Split `methodology-reference` skill into 3 focused sub-skills | LOW | Small | Better skill triggering accuracy | One skill covering NCT+NACT+NSCT is too broad for auto-selection |
 | 6 | Add counterexample interpretation skill | LOW | Small | Better failure UX | No guidance for understanding verification failures |
 | 7 | Add incremental spec development skill | LOW | Small | Better iteration workflow | Current skills assume whole-file/protocol scope |
@@ -297,7 +297,7 @@ Defines `CompiledModuleIR`, `RequirementIR`, `MixinIR`, `InvariantIR`, etc. Only
 ## 7. Conclusion
 
 The Ivy LSP + MCP tooling is **well-positioned relative to SOTA protocol verification tools**. It is:
-- The **most feature-complete LSP** in the protocol verification space (17 features vs ProVerif's ~8, TLA+'s in-development, SPIN/Tamarin's zero)
+- The **most feature-complete LSP** in the protocol verification space (19 features vs ProVerif's ~8, TLA+'s in-development, SPIN/Tamarin's zero)
 - The **only tool with RFC traceability** integrated into the specification language
 - The **only tool with specification scaffolding** (pattern library + 14-layer template)
 - The **only tool with both verification AND test generation** in one pipeline
@@ -328,7 +328,9 @@ The main optimization opportunities are architectural simplification (dual graph
 | 14 | `ivy_patterns` | `mode`: analyze/validate/compare/check | RequirementGraph | Pattern analysis + scaffold checking |
 | 15 | `ivy_pattern_scaffold` | `pattern`, `protocol`, `wire_format` | Templates | Generate Ivy source from pattern |
 
-## Appendix B: LSP Feature Registration (17 Features)
+*Note: 15 backward-compatibility aliases for the pre-consolidation tool names are also registered but not listed here.*
+
+## Appendix B: LSP Feature Registration (19 Features)
 
 All registered in `server.py` via `register()` calls:
 
@@ -351,6 +353,8 @@ All registered in `server.py` via `register()` calls:
 | Commands | `features/commands.py` | Custom LSP commands |
 | Visualization | `features/visualization.py` | Custom RPC handlers (action reqs, coverage, graphs) |
 | Monitoring | `features/monitoring.py` | Custom RPC handlers (11 endpoints) |
+| Implementation | `features/implementation.py` | `textDocument/implementation` |
+| Call Hierarchy | `features/call_hierarchy.py` | `textDocument/prepareCallHierarchy` |
 
 ## Appendix C: Unique Capability Combination
 
@@ -363,6 +367,6 @@ No existing tool combines all of these in a single toolchain:
 5. Executable test generation from verified models (`ivy_compile`)
 6. Deployment-integrated conformance testing (Docker + PANTHER CI/CD)
 7. AI-accessible tooling surface (15 MCP tools) for all of the above
-8. Full IDE-grade code intelligence (17-feature LSP)
+8. Full IDE-grade code intelligence (19-feature LSP)
 
 Each capability exists independently in various tools. The Ivy PANTHER ecosystem is, to our knowledge, the only system that integrates all eight in a single toolchain.

--- a/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
+++ b/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
@@ -1,430 +1,368 @@
-# Ivy Tooling Ecosystem: Strategic Evaluation & Consolidation
+# Ivy Tooling Ecosystem: Strategic Evaluation (Post-Consolidation)
 
 **Date**: 2026-03-13
-**Scope**: Full strategic assessment of Ivy formal verification tooling (MCP + LSP + Claude Code integration)
-**Inputs**: Audit scorecard (25 MCP tools, 14 LSP features), state-of-the-art survey, over-engineering analysis
-**Goal**: Consolidation plan, gap analysis, and implementation roadmap
+**Status**: Post-consolidation assessment (tools reduced from 25→15, mode-based dispatch implemented)
+**Scope**: LSP + MCP + Claude Code plugin evaluation against protocol-focused SOTA
+**Prior work**: `2026-03-13-ivy-tooling-audit-design.md` (audit), `2026-03-13-ivy-tooling-audit-results.md` (results)
+**Goal**: Identify strengths, over-engineering, dead code, and gaps vs state-of-the-art protocol verification tools
 
 ---
 
-## 1. State of the Art Comparison
+## 1. State-of-the-Art Comparison (Protocol Verification Tools)
 
-This section compares the Ivy tooling ecosystem against established formal verification, specification management, and AI-assisted development platforms across five dimensions. Each dimension surfaces where Ivy leads, where it lags, and where consolidation would sharpen its competitive position.
+### 1.1 Code Intelligence (LSP)
 
-### Dimension 1: Code Intelligence (LSP)
+| Capability | Ivy LSP | TLA+ (VS Code ext) | SPIN/Promela | Tamarin (VS Code ext) | ProVerif (vscode-proverif) |
+|---|---|---|---|---|---|
+| **LSP server** | Full (pygls, 17 registered features) | Shipping (SANY-based VS Code ext); TLAPM proof LSP in development | None | None (tree-sitter grammar; interactive web prover provides exploration) | Partial (syntax + parse errors + signatures) |
+| **Go-to-definition** | Cross-file + include resolution | Yes | No | No | Yes (Ctrl+click) |
+| **Find references** | Workspace-wide | Yes | No | No | Yes |
+| **Completions** | Context-aware (dot-access, includes, keywords, semantic) | Basic (keywords + identifiers) | No | No | No |
+| **Hover info** | Types + RFC annotations + cross-ref summaries | Types + operator definitions | No | No | Signatures |
+| **Diagnostics** | 3-tier: structural (<50ms) → AST (<200ms) → compiler (background) | SANY inline (single tier) | iSpin panel (external GUI) | Wellformedness via tree-sitter | Parse errors only |
+| **Code actions** | Quick fixes for common issues | No | No | In-rule rename only | No |
+| **Code lens** | RFC coverage metrics per action/monitor | No | No | No | No |
+| **Rename** | Lexical with validation | In development (proof step rename) | No | In-rule only | Semantic (F2) |
+| **Folding ranges** | Yes (structural) | No | No | No | No |
+| **Selection range** | Yes (smart expansion) | No | No | No | No |
+| **Signature help** | Action parameter hints | No | No | No | Yes |
 
-| Capability | Lean 4 LSP | Dafny VS Code | TLA+ Toolbox | SPARK Ada GPS | Ivy LSP |
-|------------|:----------:|:-------------:|:------------:|:-------------:|:-------:|
-| Go-to-definition | Full (cross-file, cross-import) | Full | Full | Full | Partial (cross-include works; declarations return "not found"; dotted paths fail) |
-| Find references | Full with scope awareness | Full | Find-in-project | Full with read/write distinction | Good cross-file (376 refs for `cid`); self-refs omitted; no read/write split |
-| Hover info | Type + tactic state + doc | Type + triggers + verified status | Operator definitions | Type + contracts + SPARK annotations | Nearly broken (1/6 correct); no RFC enrichment active yet |
-| Completion | Context-aware (tactics, terms) | Context-aware (keywords, ghost vars) | Action/variable names | Contracts + aspects | Keyword-only (not implemented in current LSP) |
-| Diagnostics | Real-time, per-line verification status | Real-time, error squiggles + counterexample gutter marks | Model-check error overlay | Flow analysis + runtime checks | 5-layer graduated analysis (structural, lexer, semantic, coverage, pattern) via MCP; push-based LSP diagnostics not testable |
-| Code lens | Proof state per declaration | Verify/debug lenses | N/A | Prove/examine lenses | Not implemented |
-| Code actions | Quick fixes for proof failures | Quick fixes, extract method | N/A | Refactoring, proof completion | Not implemented |
-| Rename | Full, safe | Full, safe | Basic find-replace | Full with semantic checks | Not tested (not exposed via Claude Code LSP tool); scope detection present |
+**Verdict**: Ivy LSP is the **most feature-complete language server** among all protocol verification tools (17 registered feature handlers). TLA+'s shipping VS Code extension provides go-to-definition, find-refs, and SANY diagnostics, but lacks completions, code lens, and code actions. ProVerif's extension provides syntax and parse error reporting but is not a full LSP. SPIN and Tamarin have no LSP (Tamarin's web prover offers interactive exploration outside the LSP protocol).
 
-**Ivy LSP strengths**:
-- **3-tier graduated analysis** (structural, semantic, pattern) via `ivy_diagnostics` provides depth no other tool matches for a single diagnostics call
-- **RFC annotation enrichment** in hover (when bracket tags exist) is unique -- no other LSP ties code symbols to normative requirements
-- **Proximity-based disambiguation** in go-to-definition resolves ambiguous names using include-graph distance, handling Ivy's flat namespace without module qualifiers
+### 1.2 Verification Integration
 
-**Ivy LSP gaps**:
-- No interactive proof state display (Lean 4 and Dafny show tactic goals/verification status per line)
-- No verification-as-you-type (Dafny and Lean 4 verify incrementally on keystroke; Ivy requires explicit `ivy_verify` MCP call)
-- Keyword-only completion (Lean 4 and Dafny offer context-aware completions including tactic suggestions)
-- No per-line verification status gutter marks (Dafny and SPARK show green/red per declaration)
+| Capability | Ivy MCP | TLA+ Toolbox | SPIN (iSpin) | Tamarin | ProVerif |
+|---|---|---|---|---|---|
+| **Verification trigger** | MCP `ivy_verify` (programmatic, cached, per-isolate) | TLC GUI + MCP (2025) | iSpin GUI panel | CLI + web prover | VS Code Ctrl+Shift+B |
+| **Counterexample output** | Structured JSON (parsed from ivy_check, wired in verification.py:155) | State graph + heatmap profiling (2025) | MSC diagrams + automata view | Interactive attack graph (web GUI) | Derivation trees (Graphviz) |
+| **Incremental verification** | Per-isolate caching (file-level, not sub-file) | Per-model (full re-check) | Per-model | Per-lemma | Full model |
+| **Interactive exploration** | No | No | Automata view | **Yes** (web-based proof tree, step-by-step goal selection) | No |
+| **Test generation** | **Yes** (`ivyc target=test` → C++ test binary) | No | No | No | No |
+| **Docker integration** | **Yes** (Docker-aware fallback for verification + compilation) | No | No | No | No |
+| **LLM orchestration** | **Yes** (15 MCP tools with typed JSON schemas) | Yes (MCP server, 2025) | No | No | No |
 
-### Dimension 2: Verification Integration
+**Ivy strengths**: Unique end-to-end pipeline (verify → compile → test binary → Docker execution). MCP integration enables AI-driven verification workflows. Per-isolate caching reduces redundant verification.
 
-| Capability | Dafny | Lean 4 | TLA+ Toolbox | Tamarin | ProVerif | Ivy MCP |
-|------------|:-----:|:------:|:------------:|:-------:|:--------:|:-------:|
-| Incremental verification | Yes (per-method, cached) | Yes (per-definition) | Per-model (full re-check) | Per-lemma | Full model | No (full model re-check each time) |
-| Counterexample display | Rich: variable values, execution trace, gutter marks | Tactic state at cursor | State graph + trace explorer | Attack graphs with MSC diagrams | Derivation trees | Raw text output only; no structured rendering |
-| State space exploration | Bounded model checking | Proof search tree | Explicit-state model checker with state graph | Constraint solving trace | Horn clause resolution | No exploration; binary pass/fail |
-| Verification-as-you-type | Yes (background worker, incremental) | Yes (persistent environment) | No (explicit run) | No (explicit run) | No (explicit run) | No (explicit `ivy_verify` call) |
-| Docker/container support | No (native or dotnet) | No (native) | No (native Java) | No (native) | No (native) | Yes (Docker-aware pipeline with fallback) |
-| Test binary generation | No (verified code is the artifact) | No (extracted code via tactics) | No | No | No | Yes (`ivyc target=test` produces C++ test binaries) |
+**Ivy gaps**: No interactive proof exploration (Tamarin's web prover is unique). Counterexample data is parsed and structured but lacks rich visualization (TLA+ has heatmaps, SPIN has MSC diagrams). No verification-as-you-type (but no competitor in this category has it either — only Lean 4 and Dafny from the general FV space offer this).
 
-**Ivy strengths**:
-- **Docker-aware pipeline**: Verification, compilation, and test execution all work inside containers, enabling CI/CD integration that no other formal tool offers natively
-- **Verification + compilation + test in one toolchain**: `ivy_verify` -> `ivy_compile` -> test binary execution is a unique pipeline; other tools stop at verification or code extraction
-- **LLM can orchestrate verification via MCP**: 25 tools with typed JSON schemas let an AI agent drive the entire verification workflow -- no other formal tool has this level of programmatic access
+### 1.3 Specification Traceability (Unique to Ivy)
 
-**Ivy gaps**:
-- **No incremental verification**: Every `ivy_verify` call re-checks the entire model. For QUIC (202 files), this is prohibitive for iterative development
-- **Raw text counterexamples**: When verification fails, output is unstructured text from `ivy_check`. Dafny and TLA+ render counterexamples as interactive execution traces
-- **No state space exploration**: The tool reports pass/fail but provides no mechanism to explore why a property holds or what states were checked
+| Capability | Ivy MCP+LSP | TLA+ | SPIN | Tamarin | ProVerif |
+|---|---|---|---|---|---|
+| **RFC requirement extraction** | Automated (`ivy_extract_requirements`): MUST/SHOULD/MAY parsing from RFC text | None | None | None | None |
+| **Inline requirement annotation** | Bracket-tags (`# [rfc9000:4.2]`) in `.ivy` files | None | None | None | None |
+| **Coverage matrix** | `ivy_coverage(mode="matrix")`: requirement → annotation mapping | None | None | None | None |
+| **Coverage gaps** | `ivy_coverage(mode="gaps")`: unguarded state vars, uncovered reqs | None | None | None | None |
+| **Coverage regression** | `ivy_coverage(mode="diff")`: baseline comparison | None | None | None | None |
+| **MUST/SHOULD/MAY metrics** | `ivy_coverage(mode="stats")`: coverage by level and layer | None | None | None | None |
+| **Manifest generation** | YAML manifests from RFC text (`ivy_extract_requirements(output="manifest")`) | None | None | None | None |
 
-### Dimension 3: Specification Traceability
+**This is a genuinely novel contribution.** No other formal verification tool — protocol-focused or general-purpose — integrates requirements traceability into the specification language. IBM DOORS, Reqtify, and Polarion exist as external traceability tools but operate outside the verification toolchain. Ivy's bracket-tag system embeds requirements directly in verified assertions, enabling simultaneous formal property verification and normative coverage tracking.
 
-| Capability | IBM DOORS Next | Reqtify | Polarion | Ivy MCP+LSP |
-|------------|:--------------:|:-------:|:--------:|:-----------:|
-| Requirement extraction | Manual import from documents | Regex-based extraction from documents | Manual + document connectors | Automated: `ivy_extract_requirements` parses MUST/SHOULD/MAY from RFC text with sentence boundary detection (4.6/5 audit score) |
-| Annotation syntax | External linking (IDs in tool, not in code) | Pragma comments in code | External linking | Inline bracket tags `[rfc9000:4.1]` embedded directly in Ivy assertions |
-| Coverage matrix | Full bidirectional traceability matrix | Forward trace from req to test | Bidirectional with work items | `ivy_traceability_matrix` + `ivy_requirement_coverage`: functional but tag format mismatch (bare `[4]` vs `rfc9000:4.1`) currently breaks matching (0% coverage despite annotations) |
-| Gap analysis | Orphan detection both directions | Missing-link reports | Gap analysis dashboards | `ivy_coverage_gaps`: detects unguarded state variables, actions without requirement annotations, missing monitor patterns |
-| Impact analysis | Change impact via bidirectional links | File-level impact tracing | Work item dependency graph | `ivy_impact_analysis`: symbol-level impact through semantic graph edges (types, actions, relations, read/write) |
-| Integration with code | Separate from code (external tool) | Embedded pragmas, build integration | Separate tool with IDE plugins | **Native**: requirements live in the same `.ivy` files as the specification, verified by the same toolchain |
+### 1.4 AI-Assisted Specification
 
-**Novel contribution**: No other formal verification tool integrates requirement traceability into the specification language itself. IBM DOORS, Reqtify, and Polarion are all external tools that link to code via IDs or pragmas. Ivy's bracket-tag annotation system (`[rfc9000:4.1]`) embeds requirements directly in assertions, enabling the toolchain to verify both the formal property AND its normative coverage simultaneously.
+| Capability | Ivy MCP+Plugin | TLA+ (MCP, 2025) | Quint (MCP) | Alloy (MCP) |
+|---|---|---|---|---|
+| **MCP tools** | 15 unified tools (verification, analysis, traceability, visualization, patterns, quality) | SANY parsing + TLC model checking | Type-check + simulate + model-check | Model generation + analysis |
+| **Specification scaffolding** | Pattern library (6 patterns) + 14-layer template + `ivy_pattern_scaffold` | None | None | None |
+| **Quality gates** | 3-tier (minimal/standard/comprehensive) via `ivy_quality(mode="gate")` | None | None | None |
+| **Workflow guidance** | 6 skills + 4 agents with methodology knowledge | None | None | None |
+| **Architecture validation** | `ivy_patterns(mode="check")`: 14-layer completeness scoring | None | None | None |
 
-**Current limitation**: The tag format mismatch (C4 in audit backlog) means this capability is architecturally present but operationally broken. Fixing the `[N]` to `rfc9000:N` mapping would unlock what is genuinely a differentiating feature.
+**Ivy is ahead** in structured semantic access for AI agents. The 15 MCP tools with typed JSON provide deeper specification-model access than any competitor. TLA+ and Quint have MCP servers but with narrower scope (parse + check).
 
-### Dimension 4: AI-Assisted Specification
+### 1.5 Protocol-Specific Analysis
 
-| Capability | GitHub Copilot | Cursor | LLM+Lean (LeanDojo) | LLM+Coq (Proverbot9001) | Ivy MCP+Plugin |
-|------------|:--------------:|:------:|:--------------------:|:------------------------:|:--------------:|
-| Code completion | Token-level, statistical | Token + semantic (codebase RAG) | Tactic prediction | Tactic prediction | Not implemented (keyword-only LSP completion) |
-| Structured semantic access | None (text-only context) | Codebase indexing (AST-level) | Lean server API (JSON) | SerAPI (S-expressions) | **21 MCP tools** with typed JSON schemas providing symbol info, include graphs, dependency analysis, traceability matrices, pattern detection |
-| Specification generation | General code generation | General with context | Proof step generation | Proof search | `ivy_pattern_scaffold` generates complete Ivy specification templates for 5 pattern types (serdes, shim, entity, variants, monitors) with documentation |
-| Workflow guidance | None | Tab-based suggestions | None | None | 14 Claude Code skills + 9 agents with methodology knowledge (specification creation workflow, quality gates, RFC analysis) |
-| Quality enforcement | Linting only | Linting + review | Type checking | Type checking | `ivy_quality_gate` (3-tier: minimal/standard/comprehensive) + `ivy_scaffold_check` (14-layer architecture validation) + `ivy_diagnostics` (5-layer graduated analysis) |
+| Capability | Ivy PANTHER | Tamarin | ProVerif | SPIN |
+|---|---|---|---|---|
+| **Protocol compliance testing** | **Yes**: RFC-level compliance with traceability | No (security properties only) | No (security properties only) | No (generic model checking) |
+| **Security property verification** | Partial (safety invariants, MitM scenarios) | **Full** (Dolev-Yao, equational theories, unbounded sessions) | **Full** (Horn clauses, unbounded) | State-based only |
+| **Test generation** | **Yes** (`ivyc target=test` → executable C++ tests) | No | No | Partial (iSpin counterexample traces) |
+| **Multi-protocol workspace** | **Yes** (QUIC, BGP, CoAP in unified workspace) | One model per analysis | One model per analysis | One model per analysis |
+| **Deployment integration** | **Yes** (Docker, CI/CD via PANTHER) | Standalone | Standalone | Standalone |
 
-**Ivy is ahead in one critical area**: Structured semantic access for AI agents. The 21 MCP tools provide typed, queryable access to the specification model that goes far beyond what any LLM+prover integration offers. LeanDojo and Proverbot9001 give LLMs access to tactic state; Ivy gives LLMs access to the entire specification architecture (symbols, dependencies, requirements, patterns, coverage, quality metrics).
-
-**Diluted by over-proliferation**: The audit found that many tools overlap significantly (e.g., `ivy_impact_analysis` / `ivy_cross_references` / `ivy_query_symbol` query the same semantic model) and 7 visualization tools ignore their scoping parameters. Consolidation from 25 to ~12 tools would improve AI performance by reducing tool-selection confusion and ensuring each tool does one thing well.
-
-### Dimension 5: Protocol-Specific Analysis
-
-| Capability | Tamarin | ProVerif | Scyther | UPPAAL | Ivy PANTHER |
-|------------|:-------:|:--------:|:-------:|:------:|:-----------:|
-| Security property verification | Yes (Dolev-Yao, equational theories) | Yes (Horn clauses, unbounded) | Yes (bounded, automatic) | Timed automata only | Partial (safety properties, invariants, not cryptographic) |
-| Compliance testing | No (security properties only) | No (security properties only) | No (security properties only) | No (timed properties only) | **Yes**: RFC requirement-level compliance with bracket-tag traceability |
-| Attack visualization | MSC attack traces | Derivation graphs | Attack graphs | Simulation traces | Raw text only (no structured attack rendering) |
-| Test generation | No (model checking only) | No (analysis only) | No (analysis only) | Test generation from traces | **Yes**: `ivyc target=test` generates executable C++ test binaries |
-| Deployment integration | No (standalone analysis) | No (standalone analysis) | No (standalone analysis) | No (standalone analysis) | **Yes**: Docker-aware, integrated with PANTHER CI/CD pipeline, tests run against real implementations |
-| Multi-protocol | No (one model per analysis) | No (one model per analysis) | Multi-protocol (limited) | Component-based | **Yes**: QUIC, BGP, CoAP, custom protocols in unified workspace |
-
-**Ivy's niche**: Protocol compliance testing with deployment integration. Tamarin, ProVerif, and Scyther excel at cryptographic security analysis but produce no executable tests and cannot check RFC compliance. UPPAAL handles timed systems but not protocol specifications. Ivy PANTHER uniquely bridges formal specification to executable conformance testing against real protocol implementations in Docker containers.
-
-**Ivy's weakness**: Security property verification. Tamarin and ProVerif handle Dolev-Yao attackers, equational theories, and unbounded sessions -- capabilities fundamentally absent from Ivy's first-order logic framework. Ivy's `quic_attacks_stack/` models MitM scenarios but at a much coarser granularity.
+**Ivy's niche**: Protocol compliance testing with deployment integration. Tamarin and ProVerif excel at cryptographic security analysis (fundamentally different capability). SPIN handles generic concurrent systems but has no protocol awareness. Ivy uniquely bridges formal specification → executable conformance testing against real implementations.
 
 ---
 
-## 2. Over-Engineering Assessment
+## 2. Correctly Implemented (Strengths)
 
-This section evaluates the current tooling surface for over-engineering: features that add complexity without proportional value, and identifies what to consolidate, cut, or keep.
+### A. Three-Tier Diagnostic Pipeline — Best-in-Class Architecture
+- **Tier 1** (<50ms): Structural checks (missing `#lang`, unmatched braces, unresolved includes) — works offline, no compiler needed
+- **Tier 2** (<200ms): AST-enriched semantic analysis via parser or fallback scanner — requirement extraction, test scope detection
+- **Tier 3** (background): Full Ivy compiler verification — type checking, invariant verification
+- **Why it matters**: No surveyed tool separates fast/slow diagnostics this cleanly. TLA+ has single-speed SANY, Tamarin has single-speed wellformedness. This lets the LSP stay responsive while deferring expensive work.
+- **Files**: `semantic/analysis_pipeline.py`, `features/diagnostics.py`
 
-### 2.1 MCP Tool Proliferation (25 -> 12)
+### B. Graceful Degradation — Adapter Pattern (Justified Complexity)
+- `NullAdapter` implementations enable full LSP functionality without Ivy compiler installed
+- Runtime-checkable Protocols (`adapters/protocols.py`) isolate heavy imports from LSP startup
+- Formula analyzer: `ImportError` fallback at `mcp_server.py:695-698` (skips READS wiring if unavailable)
+- Pattern library: `ImportError` fallback at `features/patterns.py:60-67` (returns error response if unavailable)
+- **Assessment**: NOT over-engineering. This is correct defensive design enabling light-mode LSP and MCP operation on machines without full Ivy toolchain.
+- **Files**: `adapters/null_adapter.py`, `adapters/protocols.py`, `adapters/compiler_adapter.py`
 
-**Problem**: 25 MCP tools cause tool-selection confusion for AI agents. The audit found:
-- 3 tools query the same semantic model with overlapping results (`ivy_impact_analysis`, `ivy_cross_references`, `ivy_query_symbol`)
-- `ivy_lint` is a strict subset of `ivy_diagnostics` (structural layer)
-- 7 visualization tools share broken `test_file` handling code
-- Several tools produce unusably large output without working scoping parameters
+### C. Complete Code Wiring — No Dead Code
+After deep import-chain audit (tracing from `server.py` and `mcp_server.py` through all modules):
+- **`counterexample_parser.py`** → Called at `tools/verification.py:155-160` on verification failure — parses raw ivy_check output into structured JSON
+- **`formula_analyzer.py`** → Called at `requirement_graph.py:365` via `wire_state_var_edges()`, invoked from `mcp_server.py:694` — extracts state variable references from requirement formulas
+- **`impl_block_parser.py`** → Called at `pattern_library.py:147,358` via `analyze_impl_blocks()`, used by `features/patterns.py:60` and `features/visualization.py:602` — parses implementation blocks for pattern detection
+- **`snapshots.py`** → Used by `compiler_adapter.py:166,262,289-330` — extracts module and signature snapshots from compiler state for Tier 3 enrichment
+- **All 17 LSP features**: Each has a `register()` function called from `server.py` (confirmed by grep across features/)
+- **All 15 MCP tools**: All registered via 6 modules in `tools/__init__.py` → `mcp_server.py`
+- **All 3 CLI tools**: `ivy_check`, `ivyc`, `ivy_show` confirmed available via `ivy_capabilities`
 
-**Consolidation table**:
+### D. MCP Tool Consolidation — Well-Executed (25→15)
+The consolidation recommended in the prior audit has been implemented:
 
-| Current Tool(s) | Merged Into | Rationale |
-|-----------------|-------------|-----------|
-| `ivy_lint` + `ivy_diagnostics` | **`ivy_diagnostics`** (add `layers` param) | ivy_lint is structural layer only; diagnostics is superset. Keep lint logic as fast path when `layers=["structural"]`. |
-| `ivy_impact_analysis` + `ivy_cross_references` + `ivy_query_symbol` | **`ivy_symbol_info`** | All three query the semantic graph for a symbol. Merge into one tool: symbol name -> type info + edges + references. Accept both symbol names and node_ids. |
-| `ivy_traceability_matrix` + `ivy_requirement_coverage` | **`ivy_traceability`** | Both query the same requirement manifest + annotation data. Matrix is the detail view, coverage is the summary. One tool with `detail` param. |
-| `ivy_action_requirements` + `ivy_coverage_gaps` | **`ivy_coverage`** | Both analyze action-to-requirement mapping. Action_requirements shows what's covered; coverage_gaps shows what's missing. One tool with `mode=covered|gaps|both`. |
-| `ivy_model_summary` + `ivy_layered_overview` | **`ivy_overview`** | Both produce high-level model summaries with different grouping. One tool with `group_by=file|module|layer`. |
-| `ivy_action_dependency_graph` + `ivy_state_machine_view` | **`ivy_graph`** | Both produce graph structures over actions and state. One tool with `view=dependencies|state_machine`. |
-| `ivy_scaffold_check` + `ivy_quality_gate` | **`ivy_quality`** | Scaffold_check evaluates 14-layer completeness; quality_gate checks 3-tier pass/fail. Both assess model maturity. One tool with `mode=check|gate`, `level=minimal|standard|comprehensive`. |
-| `ivy_smart_suggestions` | **Cut entirely** | All parameters ignored (1.6/5 audit score). Returns identical 114KB dump regardless of input. Resurrect only after implementing actual context-awareness. |
-| `ivy_verify` | **Keep** | Core verification, no overlap |
-| `ivy_compile` | **Keep** | Core compilation, no overlap |
-| `ivy_capabilities` | **Keep** | Environment introspection, no overlap |
-| `ivy_include_graph` | **Keep** | Unique include-chain analysis |
-| `ivy_model_info` | **Keep** | Raw `ivy_show` output, useful for debugging |
-| `ivy_extract_requirements` | **Keep** | RFC text parsing, highest audit score (4.6/5) |
-| `ivy_generate_manifest` | **Keep** | Manifest generation from RFC text |
-| `ivy_pattern_analysis` | **Keep** | Pattern detection/validation/comparison, high audit score (4.4/5) |
-| `ivy_pattern_scaffold` | **Keep** | Template generation, highest audit score (4.6/5) |
+| Unified Tool | Modes/Views | Original Tools Absorbed |
+|---|---|---|
+| `ivy_coverage` | `stats`, `matrix`, `gaps`, `diff` | `ivy_traceability_matrix`, `ivy_requirement_coverage`, `ivy_coverage_gaps` |
+| `ivy_query` | `info`, `impact`, `xrefs` | `ivy_query_symbol`, `ivy_impact_analysis`, `ivy_cross_references` |
+| `ivy_visualize` | `dependencies`, `state_machine`, `layers` | `ivy_action_dependency_graph`, `ivy_state_machine_view`, `ivy_layered_overview` |
+| `ivy_model_summary` | `summary`, `requirements` | `ivy_model_summary` (old), `ivy_action_requirements` |
+| `ivy_quality` | `suggestions`, `gate` | `ivy_smart_suggestions`, `ivy_quality_gate` |
+| `ivy_patterns` | `analyze`, `validate`, `compare`, `check` | `ivy_pattern_analysis`, `ivy_scaffold_check` |
 
-**Result**: 25 tools -> 12 tools (7 merged pairs, 1 cut, 10 kept, 1 new merged tool)
+Retained as independent: `ivy_verify`, `ivy_compile`, `ivy_model_info`, `ivy_diagnostics`, `ivy_lint`, `ivy_include_graph`, `ivy_capabilities`, `ivy_extract_requirements`, `ivy_pattern_scaffold`
 
-### 2.2 Agent Proliferation (9 -> 4)
+**Result**: Clean mode-based dispatch. Reduced tool-selection confusion for AI agents. Lazy initialization of expensive models.
 
-**Problem**: 9 specialized agents fragment the workflow. An LLM choosing between 9 agents faces the same combinatorial confusion as choosing between 25 tools.
+### E. RFC Traceability — Unique and Unmatched
+See §1.3. No other formal verification tool integrates this. The system is architecturally complete: extraction → manifest → annotation → coverage → gap analysis → regression detection.
 
-| Current Agents | Merged Into | Rationale |
-|----------------|-------------|-----------|
-| `spec-author`, `spec-reviewer`, `pattern-advisor` | **`specification-agent`** | All three operate on specification creation/editing. One agent with mode switching. |
-| `verification-runner`, `diagnostics-analyst` | **`verification-agent`** | Both drive verification tools and interpret results. |
-| `coverage-tracker`, `traceability-auditor` | **`compliance-agent`** | Both analyze requirement coverage and traceability. |
-| `scaffold-generator`, `quality-assessor` | **`quality-agent`** | Both evaluate and improve model quality/completeness. |
-| `workflow-orchestrator` | **Cut** | Meta-agent that dispatches to other agents; with 4 well-scoped agents, orchestration is simpler and can be handled by the primary Claude conversation. |
+### F. Pattern Library + Scaffolding — Unique Differentiator
+- 14-layer canonical decomposition: types → frames → packets → connection → crypto → shim → behavior → monitors → properties → test_specs → application → recovery → extensions → documentation
+- 6 pattern types: serdes, variants, monitors, shims, modules, entities
+- Connected chain: `pattern_library.py` → `features/patterns.py` → MCP `ivy_patterns` tool → `ivy_pattern_scaffold` tool
+- Completeness checking: `ivy_patterns(mode="check")` scores against 14-layer template
+- **Files**: `analysis/pattern_library.py`, `analysis/impl_block_parser.py`, `features/patterns.py`, `tools/patterns.py`
 
-**Result**: 9 agents -> 4 agents
+### G. Plugin Enforcement Architecture — Good Developer Experience
+- **PreToolUse hook** (`block-direct-ivy.sh`): Warns about direct `ivy_check`/`ivyc`/`ivy_show` CLI calls, maps to MCP equivalents
+- **PostToolUse hook** (`post-write-ivy-lint.sh`): Auto-lints `.ivy` files on Write/Edit (checks `#lang`, brace balance, non-empty)
+- **SessionStart hook** (`detect-ivy-workspace.sh`): Auto-detects workspace type (PANTHER project vs standalone), sets `IVY_WORKSPACE_ROOT`
+- All hooks non-blocking (exit 0, advisory only), correct behavior
 
-### 2.3 Skill Proliferation (16 -> 6)
-
-**Problem**: 16 skills create a large surface area where many skills overlap or are thin wrappers around a single MCP tool call.
-
-| Current Skills | Merged Into | Rationale |
-|----------------|-------------|-----------|
-| `create-spec`, `create-from-rfc`, `scaffold-protocol` | **`/spec-create`** | All produce new specification files. One skill with `--from-rfc`, `--from-pattern`, `--blank` flags. |
-| `run-verification`, `run-diagnostics`, `run-lint` | **`/verify`** | All invoke verification/analysis tools. One skill with `--mode verify|diagnostics|lint`. |
-| `check-coverage`, `check-traceability`, `check-quality` | **`/assess`** | All evaluate model quality from different angles. One skill combining all checks with summary. |
-| `generate-manifest`, `extract-requirements` | **`/rfc-tools`** | Both process RFC text. One skill with subcommands. |
-| `show-model`, `show-graph`, `show-overview` | **`/inspect`** | All display model information. One skill with `--view model|graph|overview|symbols`. |
-| `pattern-detect`, `pattern-scaffold` | **`/patterns`** | Both work with the pattern catalog. One skill with `--detect` and `--scaffold` modes. |
-| Remaining standalone skills | **Keep individually if distinct** | Skills that map to unique workflows (e.g., `fix-diagnostics`, `explain-error`) remain if they provide genuine multi-step orchestration. |
-
-**Result**: 16 skills -> 6 skills
-
-### 2.4 SubagentStop Quality Gates: Cut
-
-**Current behavior**: A `SubagentStop` hook kills sub-agents if quality thresholds are not met.
-
-**Cut rationale**:
-- Produces confusing UX when agents are terminated mid-task
-- Quality enforcement is better handled at the _result_ level (reject output, don't kill the worker)
-- The consolidated `ivy_quality` tool provides the same gate checks on demand
-- Agents should be allowed to complete and report, with quality issues surfaced in the response
-
-### 2.5 PreToolUse Hook: Soften to Warning
-
-**Current behavior**: A `PreToolUse` hook blocks tool calls that violate preconditions (e.g., calling `ivy_verify` without an active test file).
-
-**Soften rationale**:
-- Blocking tool calls disrupts agent workflow and produces cryptic "tool call rejected" errors
-- The underlying tools already have error handling (audit scored 3-4/5 on error handling)
-- Better approach: emit a warning in the tool response (e.g., `"warning": "No active test file set; results may be workspace-global"`) and let the agent decide
-- Keep the hook for genuinely dangerous operations (path traversal is already handled by `_validate_path`)
-
-### 2.6 Borderline (Keep but Simplify)
-
-| Component | Current State | Simplification |
-|-----------|---------------|----------------|
-| **14-layer template architecture** | Scaffold_check evaluates 14 layers (types, packet, frame, connection, crypto, shim, behavior, monitors, properties, test_specs, application, recovery, extensions, documentation). | Keep the layer model -- it's architecturally sound and unique. But simplify scoring: instead of binary present/absent per layer, add weighted scoring based on layer importance for the target protocol. Not every protocol needs all 14 layers. |
-| **Docker executor in MCP** | `ivy_compile` and `ivy_verify` spawn Docker containers when tools aren't on PATH. Silent fallback. | Keep Docker execution (it's a competitive advantage). Add `"execution_mode": "docker"|"subprocess"` to response (M2 from audit backlog). Log fallback at INFO. |
-| **Slash command routing** | 16 slash commands route to skills via Claude Code's skill system. | Reduce to 6 slash commands (matching consolidated skills). Ensure each maps to a genuine multi-step workflow, not a single tool call. |
-
-### 2.7 Well-Designed (Keep As-Is)
-
-These components scored well in the audit and represent genuine engineering value:
-
-| Component | Why Keep | Audit Evidence |
-|-----------|----------|----------------|
-| **RFC traceability system** | Unique in formal verification space. Bracket-tag annotations + manifest + coverage matrix = novel contribution. | `ivy_extract_requirements` scored 4.6/5. Architecture is sound; only tag format matching needs fixing (C4). |
-| **Semantic graph** | Powers symbol resolution, impact analysis, cross-references. Lightweight regex-based but effective for Ivy's syntax. | Correctly resolves types, actions, relations, functions. Sparse edges are a known limitation, not a design flaw. |
-| **3-tier graduated analysis** | Structural (fast, no state) -> Semantic (model-aware) -> Pattern (architecture-aware). Each layer adds cost and depth. | `ivy_diagnostics` scored 3.6/5, best in G3. 182 diagnostics for quic_frame.ivy across 5 layers shows depth. |
-| **Include resolver** | Handles Ivy's include-path-based module system with ambiguity detection and proximity ranking. | Powers go-to-definition (cross-include works), findReferences (376 results for `cid`), and the include graph. |
-| **Lazy initialization** | Semantic model, include graph, and file index built on first access, not on server startup. | Prevents 680-file indexing on cold start. Tools that don't need the semantic model don't pay for it. |
-| **PostToolUse lint hook** | Runs `ivy_lint` automatically after file modifications to catch structural errors immediately. | Fast feedback loop. Lint is cheap (sub-millisecond for structural checks). Keeps the "break early" philosophy. |
-| **SessionStart detection** | Detects workspace layout, available protocols, and tool capabilities at session start. | Provides context to agents/skills without requiring explicit initialization calls. |
-| **Path traversal protection** | `_validate_path()` uses `os.path.realpath` + prefix check. Rejects `../../../etc/passwd`. | Confirmed working in audit (security scenario 7). Correct approach. |
+### H. Agent Specialization — Well-Scoped
+| Agent | Focus | Tool Access | Assessment |
+|---|---|---|---|
+| `spec-analyst` | Navigation, exploration, verification, error diagnosis | Read, Write, Edit, Bash, Grep, Glob | Correct: broadest toolset for broadest scope |
+| `model-reviewer` | Quality review, invariant checking, best practices | Read, Grep, Glob (read-only) | Correct: read-only enforces review-not-modify |
+| `methodology-guide` | NCT/NACT/NSCT workflow guidance | Read, Write, Edit, Bash, Grep, Glob | Correct: needs write access for guided creation |
+| `traceability-agent` | RFC extraction, manifest generation, coverage audits | Read, Write, Edit, Bash, Grep, Glob, WebFetch | Correct: WebFetch for RFC access |
 
 ---
 
-## 3. Missing Capabilities (Post-Consolidation)
+## 3. Over-Engineered / Should Be Optimized
 
-After consolidation reduces noise, these are the genuine capability gaps that, if filled, would move Ivy tooling from "useful" to "competitive with state-of-the-art."
+### A. Dual Graph Storage — MEDIUM Priority
 
-### Priority 1: Incremental Verification Feedback
+**Problem**: Two parallel graph structures maintain overlapping data with separate locks.
 
-**Gap**: Every `ivy_verify` call re-checks the entire model. For QUIC (202 files), this means multi-minute verification cycles even for single-line changes. Lean 4 and Dafny verify incrementally per-definition.
+| Graph | File | Purpose | Size |
+|---|---|---|---|
+| `SemanticModel` | `semantic/model.py` (252 lines) | General-purpose graph: symbols, types, RFC annotations | 4 index structures, 5 query methods |
+| `RequirementGraph` | `analysis/requirement_graph.py` (400+ lines) | Specialized: actions → requirements → state vars | Domain-specific edges (CONSTRAINS, WRITES, COVERS, READS, DEPENDS_ON) |
 
-**Proposed approach**:
-- Track file modification timestamps and include-graph edges
-- On `ivy_verify`, compute the "dirty set" (modified files + their transitive dependents)
-- If dirty set is small, pass only affected isolates to `ivy_check`
-- Cache verification results keyed by file content hash + dependency hashes
-- Expose `"incremental": true|false` and `"cached_isolates": N` in response
+**Evidence of duplication**:
+- Both store requirements as nodes with edges
+- `coverage_hints.py` queries RequirementGraph directly
+- `features/*.py` query SemanticModel
+- `semantic/nodes.py:14` imports from `requirement_graph` (tight coupling)
+- `mcp_server.py` builds both sequentially (lines ~650-710)
 
-**Complexity**: High. Requires understanding Ivy's isolate boundaries and which checked properties depend on which definitions. May require cooperation with `ivy_check` itself (currently treats the model as monolithic).
+**Recommendation**: Migrate RequirementGraph's specialized queries into SemanticModel as domain-specific methods. Reconcile edge type enums (`EdgeType` in requirement_graph vs `SemanticEdgeType` in semantic model). Single graph, single lock, single source of truth.
 
-**Impact**: Transforms the development loop from "edit -> wait minutes -> see result" to "edit -> wait seconds -> see result." This is the single biggest productivity gap versus Lean 4 and Dafny.
+**Risk**: RequirementGraph's edge types are more granular. Need careful mapping.
 
-### Priority 2: Counterexample Rendering
+### B. Analysis Pipeline State Complexity — MEDIUM Priority
 
-**Gap**: When `ivy_verify` fails, the output is raw `ivy_check` text. Dafny shows variable values at each step; TLA+ shows a state graph; Tamarin shows MSC attack traces.
+**File**: `semantic/analysis_pipeline.py` (874 lines, 37+ public methods)
 
-**Proposed approach**:
-- Parse `ivy_check` failure output to extract: failing property, counterexample trace (variable assignments per step), and the violated invariant
-- Structure as JSON: `{"property": "...", "trace": [{"step": 1, "state": {"var": "val", ...}}, ...], "violated_invariant": "..."}`
-- For protocol-specific rendering: map state variables to protocol concepts (e.g., `stream_seen` -> "Stream X is in state Y")
-- Optionally generate Mermaid sequence diagrams for protocol traces
+**Problem**: Tier 2 (AST) and Tier 3 (compiler) have overlapping parse+analyze steps with separate thread coordination:
+- `file_generation` OrderedDict tracks per-file generation counts
+- `_bulk_running` and `_bulk_compile_running` boolean flags
+- Separate locks for different tiers
 
-**Complexity**: Medium. `ivy_check` output format is semi-structured. Parsing requires pattern matching but not compiler-level analysis.
+**Recommendation**: The 3-tier *concept* is excellent (§2A). The *implementation* could consolidate Tier 2/3 coordination into a single "deep analysis" state machine. Estimated ~30% reduction in coordination complexity without changing the user-facing behavior.
 
-**Impact**: Makes verification failures actionable. Currently, an LLM receiving raw counterexample text must guess at the structure. Structured traces let the agent explain failures and suggest fixes.
+### C. SemanticModel Over-Indexed — LOW Priority
 
-### Priority 3: Coverage Regression Detection
+**File**: `semantic/model.py` (252 lines)
 
-**Gap**: No mechanism detects when code changes reduce requirement coverage. The `ivy_traceability` tools report current coverage but don't compare against a baseline.
+4 index structures maintained eagerly on every `add_node`/`add_edge`:
+- `_edges`: Set[Tuple] for deduplication
+- `_outgoing`: Dict[str, List[Tuple]] for forward queries
+- `_incoming`: Dict[str, List[Tuple]] for backward queries
+- `_nodes_by_file`: Dict[str, Set[str]] for file-scoped queries
+- `_nodes_by_type`: Dict[type, Dict[str, Any]] for type-scoped queries
 
-**Proposed approach**:
-- Store coverage snapshots as JSON baselines (per-protocol, per-commit)
-- On `ivy_coverage --mode=regression`, diff current coverage against baseline
-- Report: newly uncovered requirements, newly covered requirements, coverage delta percentage
-- Integrate with PANTHER CI/CD: fail the pipeline if coverage drops below threshold
+Only 5 public query methods actually used. Typical graph: <10K nodes.
 
-**Complexity**: Low-medium. Coverage computation already exists. The addition is baseline storage and diffing.
+**Recommendation**: Lazy-build `_nodes_by_file` and `_nodes_by_type` indexes on first query. Keep `_outgoing`/`_incoming` eagerly built (justified for cross-reference queries).
 
-**Impact**: Prevents silent requirement de-coverage during model evolution. Essential for any project using Ivy for compliance testing.
+### D. Compilation IR Sub-Type Granularity — LOW Priority
 
-### Priority 4: Guided Spec Creation Wizard
+**File**: `compilation/ir.py`
 
-**Gap**: Creating a new protocol specification requires knowing the 14-layer architecture, naming conventions, include patterns, and requirement annotation syntax. Currently, `ivy_pattern_scaffold` generates individual files but doesn't orchestrate the full creation workflow.
+Defines `CompiledModuleIR`, `RequirementIR`, `MixinIR`, `InvariantIR`, etc. Only `CompiledModuleIR` and its top-level fields are consumed by `graph_enrichment.py`. Sub-IR types have unused granularity.
 
-**Proposed approach**:
-- Interactive multi-step workflow (via Claude Code skill):
-  1. Input: protocol name, RFC document(s), target layers
-  2. Extract requirements from RFC (`ivy_extract_requirements`)
-  3. Generate manifest (`ivy_generate_manifest`)
-  4. Scaffold each requested layer (`ivy_pattern_scaffold`)
-  5. Run quality gate (`ivy_quality` in `gate` mode)
-  6. Report: created files, coverage baseline, next steps
-- Store the result as a new protocol directory with proper structure
-
-**Complexity**: Medium. All building blocks exist. The addition is orchestration logic and state management across steps.
-
-**Impact**: Lowers the barrier to entry for new protocol models. Currently requires deep Ivy expertise; the wizard would make it accessible to protocol engineers who know their RFC but not Ivy syntax.
+**Recommendation**: Trim to the fields actually consumed. Low urgency — it works, just has unused data classes.
 
 ---
 
-## 4. Implementation Roadmap
+## 4. Gaps vs SOTA — Improvement Opportunities
 
-### Phase 1: Consolidation (2-3 weeks)
+### A. Counterexample Visualization — HIGH Value (Foundation Exists)
 
-| Step | Action | Files Affected | Risk |
-|------|--------|----------------|------|
-| 1 | **Merge `ivy_lint` into `ivy_diagnostics`**: Add `layers` parameter. When `layers=["structural"]`, use fast path. Deprecate `ivy_lint` tool registration. | `tools/verification.py`, `tools/analysis.py`, `mcp_server.py` | Low. Lint logic already exists in diagnostics structural layer. |
-| 2 | **Merge semantic query tools**: Combine `ivy_impact_analysis` + `ivy_cross_references` + `ivy_query_symbol` into `ivy_symbol_info`. Accept both symbol names and node_ids. Return unified response with type info, edges, and references. | `tools/traceability.py`, `tools/analysis.py`, `mcp_server.py` | Medium. Three different response schemas must be unified. |
-| 3 | **Merge traceability tools**: Combine `ivy_traceability_matrix` + `ivy_requirement_coverage` into `ivy_traceability` with `detail` parameter. | `tools/traceability.py` | Low. Both already query the same data. |
-| 4 | **Merge visualization tools**: Combine overlapping pairs (`action_requirements`+`coverage_gaps`, `model_summary`+`layered_overview`, `dependency_graph`+`state_machine_view`). Cut `ivy_smart_suggestions`. Fix `test_file` filtering for all remaining tools. | `tools/visualization.py`, `features/visualization.py` | High. 7 tools with shared broken code. Fix the filtering first, then merge. |
-| 5 | **Merge quality tools**: Combine `ivy_scaffold_check` + `ivy_quality_gate` into `ivy_quality`. | `tools/quality.py`, `features/quality_gates.py` | Low. Distinct logic, just needs unified entry point. |
+**Current state**: `counterexample_parser.py` IS wired in at `tools/verification.py:155-160`. When `ivy_verify` fails, it parses raw output and adds a structured `counterexample` field to the JSON result.
 
-### Phase 2: Gap Filling (3-4 weeks)
+**Gap**: The parsed data is returned but not richly formatted. Compare:
+- **TLA+ Toolbox**: State graph + heatmap execution profiling (new 2025)
+- **SPIN**: MSC diagrams + automata view (iSpin GUI)
+- **Tamarin**: Interactive attack graph in web browser
 
-| Step | Action | Dependencies | Risk |
-|------|--------|--------------|------|
-| 6 | **Fix critical bugs (C1-C8)**: Workspace root misconfiguration, `test_file` parameter ignored, tag format mismatch, include graph path mismatch, hover broken, workspaceSymbol unfiltered, `file_path` returns empty, `includes_resolve` always fails. | Phase 1 Step 4 fixes C2/C3. Others are independent. | Medium. C1 and C5 require path normalization changes that could break existing users. |
-| 7 | **Implement counterexample rendering (Priority 2)**: Parse `ivy_check` failure output into structured JSON. | Independent of Phase 1. | Medium. Output format parsing is fragile. |
-| 8 | **Implement coverage regression detection (Priority 3)**: Baseline storage, diffing, CI integration. | Phase 1 Step 3 (merged traceability tool). | Low. Incremental addition to existing coverage logic. |
+**Improvement**: Add formatted counterexample display:
+1. Format parsed counterexample as a readable state trace in `ivy_verify` output
+2. Map state variables to protocol concepts (e.g., `stream_seen` → "Stream X is in state Y")
+3. Add LSP diagnostics with "related information" links to counterexample states
+4. Optionally generate Mermaid sequence diagrams for protocol state traces
 
-### Phase 3: Design Document (1 week)
+**Effort**: Small-Medium. Parser exists and works. Need formatting logic.
 
-| Step | Action | Dependencies |
-|------|--------|--------------|
-| 9 | **Write strategic evaluation document** (this document). Produce consolidated architecture diagram, updated tool catalog, and handoff notes for incremental verification (Priority 1) and guided spec wizard (Priority 4) as future work. | Phases 1-2 for validation data. |
+### B. Verification Status Dashboard — MEDIUM Value
 
-### Timeline Summary
+**Current**: `monitoring.py` provides 11 RPC handlers for server status, pipeline progress, indexer stats, etc.
 
-```
-Week 1-2:  Phase 1 Steps 1-3 (low-risk merges)
-Week 2-3:  Phase 1 Steps 4-5 (visualization merge + quality merge)
-Week 3-5:  Phase 2 Step 6 (critical bug fixes, parallelizable with Step 5)
-Week 5-6:  Phase 2 Steps 7-8 (counterexample rendering + coverage regression)
-Week 7:    Phase 3 Step 9 (this document finalized, architecture review)
-```
+**Gap**: No unified "verification dashboard" showing per-isolate pass/fail across all workspace files.
 
----
+**Improvement**: Add workspace-level verification summary tool/view. The per-isolate cache in `tools/verification.py` already tracks this data (`_verify_cache` with per-file entries). Expose as a new MCP tool mode or monitoring RPC.
 
-## 5. Verification Checklist
+### C. Incremental Verification — MEDIUM Value
 
-### After Phase 1 (Consolidation)
+**Current**: Full `ivy_check` on each `ivy_verify` call. Per-isolate caching helps (skip if file unchanged).
 
-- [ ] Tool count reduced from 25 to 12 (verify with `ivy_capabilities`)
-- [ ] All deprecated tool names return a helpful deprecation message pointing to the replacement
-- [ ] `ivy_diagnostics` with `layers=["structural"]` produces identical output to old `ivy_lint`
-- [ ] `ivy_symbol_info` with symbol name returns type info + edges (formerly 3 separate calls)
-- [ ] `ivy_traceability` with `detail=true` returns full matrix; `detail=false` returns coverage summary
-- [ ] `ivy_coverage` with `mode=covered` matches old `ivy_action_requirements`; `mode=gaps` matches old `ivy_coverage_gaps`
-- [ ] `ivy_overview` with `group_by=file` matches old `ivy_model_summary`; `group_by=layer` matches old `ivy_layered_overview`
-- [ ] `ivy_graph` with `view=dependencies` matches old `ivy_action_dependency_graph`; `view=state_machine` matches old `ivy_state_machine_view`
-- [ ] `ivy_quality` with `mode=check` matches old `ivy_scaffold_check`; `mode=gate` matches old `ivy_quality_gate`
-- [ ] `ivy_smart_suggestions` is removed; no tool registered under that name
-- [ ] All 12 remaining tools have working `protocol` parameter for scoping
-- [ ] All visualization tools correctly filter by `test_file` when provided
-- [ ] Output size for QUIC full model < 100KB for any single tool call (relative paths, proper scoping)
-- [ ] Existing test suite passes (adjust for new tool names)
-- [ ] Claude Code plugin configuration updated: 6 skills, 4 agents
+**Gap**: Modifying one isolate re-verifies the whole file. TLA+ Toolbox re-checks the full model too, so this is not a gap vs SOTA in this category — only vs general FV tools (Lean 4, Dafny).
 
-### After Phase 2 (Gap Filling)
+**Improvement**: Track file content hash per isolate. Only re-verify isolates whose definitions (or transitive dependencies) changed. The caching infrastructure already exists.
 
-- [ ] C1 fixed: `ivy_verify`/`ivy_compile`/`ivy_lint`/`ivy_model_info` resolve paths with `protocol-testing/` prefix fallback; error messages include resolved absolute path
-- [ ] C4 fixed: `ivy_traceability` correctly maps bare numeric bracket tags `[N]` to manifest requirement IDs `rfc9000:N`; QUIC coverage > 0%
-- [ ] C5 fixed: `ivy_include_graph` path keys normalized; individual file queries return non-empty `includes` list
-- [ ] C6 fixed: LSP hover returns correct info for at least 4/6 original test scenarios
-- [ ] C7 fixed: LSP workspaceSymbol filters results by query text
-- [ ] H8 fixed: `ivy_quality` gate `includes_resolve` exempts known Ivy stdlib modules; QUIC passes `minimal` gate
-- [ ] H10 fixed: Dotted names (`frame.stream.handle`) resolve correctly in `ivy_symbol_info`
-- [ ] Counterexample rendering: `ivy_verify` failure response includes `"counterexample": {"trace": [...], "violated_property": "..."}` when available
-- [ ] Coverage regression: `ivy_traceability --mode=regression --baseline=<path>` correctly reports coverage delta
-- [ ] No regressions in audit scores: re-run audit scenarios for merged tools, all scores >= original tool scores
+### D. Semantic Rename — LOW Value
+
+**Current**: Lexical rename with validation at `features/rename.py`.
+
+**Gap**: ProVerif has semantic rename (F2). For Ivy's `include`-based composition, semantic rename requires full type resolution across files.
+
+**Assessment**: Not worth the complexity investment for the protocol verification use case. Current lexical approach is safe and works for common cases.
 
 ---
 
-## Appendix A: Current Tool Inventory (Pre-Consolidation)
+## 5. Skill/Agent Optimization
 
-For reference, the full list of 25 MCP tools with their audit scores and consolidation target:
+### Well-Designed (Keep As-Is)
+- **`spec-analyst` agent**: Correct tool restrictions, comprehensive LSP+MCP coordination
+- **`tooling-reference` skill**: Essential decision table (15+ tasks → recommended tool)
+- **`ivy-lsp-walkthrough` skill**: Best onboarding material — concrete end-to-end example on QUIC spec
+- **`traceability-agent`**: Well-scoped (RFC extraction → manifest → coverage audit)
+- **`ivy-writing-guide` skill**: Covers Ivy syntax, test spec patterns, RFC bracket-tag annotations
 
-| # | Current Tool | Avg Score | Group | Consolidation Target |
-|---|-------------|:---------:|:-----:|---------------------|
-| 1 | ivy_lint | 2.0 | G1 | Merge into `ivy_diagnostics` |
-| 2 | ivy_verify | 2.0 | G1 | **Keep** |
-| 3 | ivy_compile | 2.0 | G1 | **Keep** |
-| 4 | ivy_model_info | 2.2 | G1 | **Keep** |
-| 5 | ivy_capabilities | 3.2 | G2 | **Keep** |
-| 6 | ivy_include_graph | 2.4 | G2 | **Keep** |
-| 7 | ivy_diagnostics | 3.6 | G3 | **Keep** (absorbs ivy_lint) |
-| 8 | ivy_traceability_matrix | 2.4 | G4 | Merge into `ivy_traceability` |
-| 9 | ivy_requirement_coverage | 2.6 | G4 | Merge into `ivy_traceability` |
-| 10 | ivy_impact_analysis | 2.8 | G4 | Merge into `ivy_symbol_info` |
-| 11 | ivy_extract_requirements | 4.6 | G4 | **Keep** |
-| 12 | ivy_generate_manifest | 3.8 | G4 | **Keep** |
-| 13 | ivy_cross_references | 2.4 | G4 | Merge into `ivy_symbol_info` |
-| 14 | ivy_query_symbol | 3.2 | G4 | Merge into `ivy_symbol_info` |
-| 15 | ivy_action_requirements | 2.6 | G5 | Merge into `ivy_coverage` |
-| 16 | ivy_model_summary | 2.6 | G5 | Merge into `ivy_overview` |
-| 17 | ivy_coverage_gaps | 2.2 | G5 | Merge into `ivy_coverage` |
-| 18 | ivy_action_dependency_graph | 2.6 | G5 | Merge into `ivy_graph` |
-| 19 | ivy_state_machine_view | 3.2 | G5 | Merge into `ivy_graph` |
-| 20 | ivy_layered_overview | 2.8 | G5 | Merge into `ivy_overview` |
-| 21 | ivy_smart_suggestions | 1.6 | G5 | **Cut** |
-| 22 | ivy_pattern_analysis | 4.4 | G6 | **Keep** |
-| 23 | ivy_pattern_scaffold | 4.6 | G6 | **Keep** |
-| 24 | ivy_scaffold_check | 4.4 | G6 | Merge into `ivy_quality` |
-| 25 | ivy_quality_gate | 4.2 | G6 | Merge into `ivy_quality` |
+### Could Be Optimized
+- **`methodology-reference` skill**: Covers all three methodologies (NCT + NACT + NSCT) in one document. Consider splitting into 3 focused sub-skills with a dispatcher that auto-selects based on context keywords (specification/compliance → NCT, attack/security → NACT, simulation/topology → NSCT).
+- **`specification-patterns` skill**: The 14-layer template is front-loaded. The "minimum viable set" (7 layers) exists but presentation buries it. Restructure to lead with quick-start path, expand to full 14 layers as needed.
+- **`workflow-reference` skill**: Overlaps with `methodology-reference` on verification workflow. Could merge verification-specific content or add clearer cross-references.
 
-## Appendix B: Post-Consolidation Tool Catalog (12 Tools)
-
-| # | Tool | Source(s) | Key Parameters | Purpose |
-|---|------|-----------|----------------|---------|
-| 1 | `ivy_verify` | Keep | `file_path`, `isolate`, `timeout` | Run formal verification via `ivy_check` |
-| 2 | `ivy_compile` | Keep | `file_path`, `target`, `timeout` | Compile Ivy model to C++ test binary |
-| 3 | `ivy_model_info` | Keep | `file_path`, `isolate` | Raw `ivy_show` model structure output |
-| 4 | `ivy_capabilities` | Keep | (none) | Report available tools, versions, Docker status |
-| 5 | `ivy_include_graph` | Keep | `file_path`, `protocol`, `max_depth` | Include chain analysis with transitive closure |
-| 6 | `ivy_diagnostics` | Keep + ivy_lint | `file_path`, `protocol`, `layers[]`, `min_severity` | Graduated 5-layer analysis |
-| 7 | `ivy_symbol_info` | impact_analysis + cross_references + query_symbol | `symbol`, `node_id`, `protocol` | Unified symbol lookup: type info + edges + references |
-| 8 | `ivy_traceability` | traceability_matrix + requirement_coverage | `protocol`, `scope_file`, `detail`, `mode` | Requirement coverage matrix and summary |
-| 9 | `ivy_coverage` | action_requirements + coverage_gaps | `protocol`, `scope_file`, `mode` | Action-to-requirement mapping (covered/gaps/both) |
-| 10 | `ivy_overview` | model_summary + layered_overview | `protocol`, `scope_file`, `group_by` | High-level model structure view |
-| 11 | `ivy_graph` | action_dependency_graph + state_machine_view | `protocol`, `scope_file`, `view`, `include_state_vars`, `state_var_filter` | Dependency and state machine graph views |
-| 12 | `ivy_quality` | scaffold_check + quality_gate | `protocol`, `mode`, `level` | Model maturity assessment (check/gate) |
-
-Plus 5 standalone tools kept as-is:
-- `ivy_extract_requirements` (4.6/5)
-- `ivy_generate_manifest` (3.8/5)
-- `ivy_pattern_analysis` (4.4/5)
-- `ivy_pattern_scaffold` (4.6/5)
-
-**Total**: 12 merged/kept + 5 standalone = 17. Further consolidation of the 5 standalone tools is not recommended as they each serve distinct, high-scoring functions.
-
-*Correction*: The 5 standalone tools are counted within the 12 above. The final tool count is **12** unique tools total (7 merged entries + 5 kept as-is = 12, after cutting `ivy_smart_suggestions` and absorbing `ivy_lint`).
+### Missing
+- **Counterexample interpretation skill**: When `ivy_verify` fails, no skill guides understanding of the structured counterexample output
+- **Incremental spec development skill**: No guided workflow for "add one requirement → verify → iterate". Current skills assume whole-file or whole-protocol scope.
+- **Automated review via quality tools**: `model-reviewer` agent uses manual checklist. Could integrate `ivy_quality(mode="gate")` and `ivy_patterns(mode="validate")` for semi-automated assessment with tool-backed evidence.
 
 ---
 
-## Appendix C: Comparison with Prior Art in Combined Verification+Traceability
+## 6. Summary: Priority Action Matrix
 
-No existing tool combines:
-1. Formal protocol specification language
-2. Automated RFC requirement extraction
-3. Inline requirement annotation in specifications
-4. Formal verification of annotated properties
-5. Executable test generation from verified models
-6. Deployment-integrated conformance testing
-7. AI-accessible tooling surface (MCP) for all of the above
+| # | Action | Priority | Effort | Impact | Justification |
+|---|---|---|---|---|---|
+| 1 | Enrich counterexample display formatting in `ivy_verify` results | HIGH | Small | Closes biggest SOTA gap | TLA+/SPIN/Tamarin all have structured counterexample rendering; Ivy has the parser but not the presentation |
+| 2 | Add verification status dashboard (workspace-level summary) | MEDIUM | Medium | Better UX for large specs | Per-isolate cache already has the data; need exposure as tool/view |
+| 3 | Merge RequirementGraph into SemanticModel | MEDIUM | Large | Single source of truth, reduced lock contention | Dual graph is the main remaining over-engineering |
+| 4 | Simplify analysis_pipeline.py Tier 2/3 state management | MEDIUM | Medium | ~30% less coordination code | 874 lines with 37+ methods; Tier 2/3 overlap in parse+analyze |
+| 5 | Split `methodology-reference` skill into 3 focused sub-skills | LOW | Small | Better skill triggering accuracy | One skill covering NCT+NACT+NSCT is too broad for auto-selection |
+| 6 | Add counterexample interpretation skill | LOW | Small | Better failure UX | No guidance for understanding verification failures |
+| 7 | Add incremental spec development skill | LOW | Small | Better iteration workflow | Current skills assume whole-file/protocol scope |
+| 8 | Lazy-build SemanticModel secondary indexes | LOW | Small | Minor perf improvement | 4 eager indexes but only 5 query methods |
+| 9 | Trim unused IR sub-types in compilation/ir.py | LOW | Small | Code clarity | Sub-IR types defined but underutilized |
 
-Each capability exists independently in various tools (Dafny for #1/#4, DOORS for #2/#3, Tamarin for #1/#4, PANTHER for #5/#6, LeanDojo for #7). The Ivy PANTHER ecosystem is, to our knowledge, the only system that integrates all seven in a single toolchain.
+---
 
-The consolidation proposed in this document does not reduce this capability set. It reduces the _surface area_ through which these capabilities are accessed, making the system easier to use for both human engineers and AI agents.
+## 7. Conclusion
+
+The Ivy LSP + MCP tooling is **well-positioned relative to SOTA protocol verification tools**. It is:
+- The **most feature-complete LSP** in the protocol verification space (17 features vs ProVerif's ~8, TLA+'s in-development, SPIN/Tamarin's zero)
+- The **only tool with RFC traceability** integrated into the specification language
+- The **only tool with specification scaffolding** (pattern library + 14-layer template)
+- The **only tool with both verification AND test generation** in one pipeline
+- **Well-wired with no dead code** (all modules connected through verified import chains)
+- **Already consolidated** (25→15 tools with clean mode-based dispatch)
+
+The main optimization opportunities are architectural simplification (dual graph merge, pipeline state reduction) rather than missing functionality. The highest-value gap to close is counterexample visualization, where the foundation (parser) already exists.
+
+---
+
+## Appendix A: Post-Consolidation Tool Catalog (15 Tools)
+
+| # | Tool | Modes/Params | Backend | Purpose |
+|---|---|---|---|---|
+| 1 | `ivy_verify` | `isolate`, `use_cache` | `ivy_check` CLI | Formal property verification with per-isolate caching |
+| 2 | `ivy_compile` | `target`, `isolate` | `ivyc` CLI / Docker | Compile to test executable |
+| 3 | `ivy_model_info` | `isolate` | `ivy_show` CLI | Display model structure |
+| 4 | `ivy_diagnostics` | `layers[]`, `min_severity` | Internal analyzers | 5-layer graduated analysis |
+| 5 | `ivy_lint` | — | Internal structural checks | Fast structural lint (<50ms) |
+| 6 | `ivy_include_graph` | `relative_path` | Regex parsing | Include dependency graph |
+| 7 | `ivy_capabilities` | — | `shutil.which()` | Report available CLI tools |
+| 8 | `ivy_coverage` | `mode`: stats/matrix/gaps/diff | SemanticModel | RFC coverage analysis |
+| 9 | `ivy_query` | `mode`: info/impact/xrefs | SemanticModel | Unified semantic query |
+| 10 | `ivy_extract_requirements` | `output`: structured/manifest | Regex | RFC text → requirements |
+| 11 | `ivy_visualize` | `view`: dependencies/state_machine/layers | RequirementGraph | Model visualization |
+| 12 | `ivy_model_summary` | `detail`: summary/requirements | RequirementGraph | Per-action summary |
+| 13 | `ivy_quality` | `mode`: suggestions/gate | RequirementGraph | Quality analysis |
+| 14 | `ivy_patterns` | `mode`: analyze/validate/compare/check | RequirementGraph | Pattern analysis + scaffold checking |
+| 15 | `ivy_pattern_scaffold` | `pattern`, `protocol`, `wire_format` | Templates | Generate Ivy source from pattern |
+
+## Appendix B: LSP Feature Registration (17 Features)
+
+All registered in `server.py` via `register()` calls:
+
+| Feature | Handler File | LSP Method |
+|---|---|---|
+| Document Symbols | `features/document_symbols.py` | `textDocument/documentSymbol` |
+| Workspace Symbols | `features/workspace_symbols.py` | `workspace/symbol` |
+| Go-to-Definition | `features/definition.py` | `textDocument/definition` |
+| Find References | `features/references.py` | `textDocument/references` |
+| Document Highlight | `features/document_highlight.py` | `textDocument/documentHighlight` |
+| Hover | `features/hover.py` | `textDocument/hover` |
+| Completion | `features/completion.py` | `textDocument/completion` |
+| Signature Help | `features/signature_help.py` | `textDocument/signatureHelp` |
+| Code Action | `features/code_action.py` | `textDocument/codeAction` |
+| Code Lens | `features/code_lens.py` | `textDocument/codeLens` |
+| Diagnostics | `features/diagnostics.py` | `textDocument/diagnostic` |
+| Rename | `features/rename.py` | `textDocument/rename` |
+| Selection Range | `features/selection_range.py` | `textDocument/selectionRange` |
+| Folding Range | `features/folding_range.py` | `textDocument/foldingRange` |
+| Commands | `features/commands.py` | Custom LSP commands |
+| Visualization | `features/visualization.py` | Custom RPC handlers (action reqs, coverage, graphs) |
+| Monitoring | `features/monitoring.py` | Custom RPC handlers (11 endpoints) |
+
+## Appendix C: Unique Capability Combination
+
+No existing tool combines all of these in a single toolchain:
+
+1. Formal protocol specification language (Ivy)
+2. Automated RFC requirement extraction (`ivy_extract_requirements`)
+3. Inline requirement annotation in specifications (bracket-tags)
+4. Formal verification of annotated properties (`ivy_verify`)
+5. Executable test generation from verified models (`ivy_compile`)
+6. Deployment-integrated conformance testing (Docker + PANTHER CI/CD)
+7. AI-accessible tooling surface (15 MCP tools) for all of the above
+8. Full IDE-grade code intelligence (17-feature LSP)
+
+Each capability exists independently in various tools. The Ivy PANTHER ecosystem is, to our knowledge, the only system that integrates all eight in a single toolchain.

--- a/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
+++ b/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
@@ -1,7 +1,7 @@
 # Ivy Tooling Ecosystem: Strategic Evaluation (Post-Consolidation)
 
 **Date**: 2026-03-13
-**Status**: Post-consolidation assessment (tools reduced from 25→15, mode-based dispatch implemented)
+**Status**: Post-consolidation assessment (tools reduced from 25→17, mode-based dispatch implemented)
 **Scope**: LSP + MCP + Claude Code plugin evaluation against protocol-focused SOTA
 **Prior work**: `2026-03-13-ivy-tooling-audit-design.md` (audit), `2026-03-13-ivy-tooling-audit-results.md` (results)
 **Goal**: Identify strengths, over-engineering, dead code, and gaps vs state-of-the-art protocol verification tools
@@ -39,7 +39,7 @@
 | **Interactive exploration** | No | No | Automata view | **Yes** (web-based proof tree, step-by-step goal selection) | No |
 | **Test generation** | **Yes** (`ivyc target=test` → C++ test binary) | No | No | No | No |
 | **Docker integration** | **Yes** (Docker-aware fallback for verification + compilation) | No | No | No | No |
-| **LLM orchestration** | **Yes** (15 MCP tools with typed JSON schemas) | Yes (MCP server, 2025) | No | No | No |
+| **LLM orchestration** | **Yes** (17 MCP tools with typed JSON schemas) | Yes (MCP server, 2025) | No | No | No |
 
 **Ivy strengths**: Unique end-to-end pipeline (verify → compile → test binary → Docker execution). MCP integration enables AI-driven verification workflows. Per-isolate caching reduces redundant verification.
 
@@ -63,13 +63,13 @@
 
 | Capability | Ivy MCP+Plugin | TLA+ (MCP, 2025) | Quint (MCP) | Alloy (MCP) |
 |---|---|---|---|---|
-| **MCP tools** | 15 unified tools (verification, analysis, traceability, visualization, patterns, quality) | SANY parsing + TLC model checking | Type-check + simulate + model-check | Model generation + analysis |
+| **MCP tools** | 17 unified tools (verification, analysis, traceability, visualization, patterns, quality) | SANY parsing + TLC model checking | Type-check + simulate + model-check | Model generation + analysis |
 | **Specification scaffolding** | Pattern library (7 patterns) + 14-layer template + `ivy_pattern_scaffold` | None | None | None |
 | **Quality gates** | 3-tier (minimal/standard/comprehensive) via `ivy_quality(mode="gate")` | None | None | None |
 | **Workflow guidance** | 6 skills + 4 agents with methodology knowledge | None | None | None |
 | **Architecture validation** | `ivy_patterns(mode="check")`: 14-layer completeness scoring | None | None | None |
 
-**Ivy is ahead** in structured semantic access for AI agents. The 15 MCP tools with typed JSON provide deeper specification-model access than any competitor. TLA+ and Quint have MCP servers but with narrower scope (parse + check).
+**Ivy is ahead** in structured semantic access for AI agents. The 17 MCP tools with typed JSON provide deeper specification-model access than any competitor. TLA+ and Quint have MCP servers but with narrower scope (parse + check).
 
 ### 1.5 Protocol-Specific Analysis
 
@@ -97,7 +97,7 @@
 ### B. Graceful Degradation — Adapter Pattern (Justified Complexity)
 - `NullAdapter` implementations enable full LSP functionality without Ivy compiler installed
 - Runtime-checkable Protocols (`adapters/protocols.py`) isolate heavy imports from LSP startup
-- Formula analyzer: `ImportError` fallback at `mcp_server.py:695-698` (skips READS wiring if unavailable)
+- Formula analyzer: `ImportError` fallback at `mcp_server.py:688-691` (skips READS wiring if unavailable)
 - Pattern library: `ImportError` fallback at `features/patterns.py:60-67` (returns error response if unavailable)
 - **Assessment**: NOT over-engineering. This is correct defensive design enabling light-mode LSP and MCP operation on machines without full Ivy toolchain.
 - **Files**: `adapters/null_adapter.py`, `adapters/protocols.py`, `adapters/compiler_adapter.py`
@@ -105,14 +105,14 @@
 ### C. Complete Code Wiring — No Dead Code
 After deep import-chain audit (tracing from `server.py` and `mcp_server.py` through all modules):
 - **`counterexample_parser.py`** → Called at `tools/verification.py:155-160` on verification failure — parses raw ivy_check output into structured JSON
-- **`formula_analyzer.py`** → Called at `requirement_graph.py:365` via `wire_state_var_edges()`, invoked from `mcp_server.py:694` — extracts state variable references from requirement formulas
-- **`impl_block_parser.py`** → Called at `pattern_library.py:147,358` via `analyze_impl_blocks()`, used by `features/patterns.py:60` and `features/visualization.py:602` — parses implementation blocks for pattern detection
-- **`snapshots.py`** → Used by `compiler_adapter.py:166,262,289-330` — extracts module and signature snapshots from compiler state for Tier 3 enrichment
+- **`formula_analyzer.py`** → Called at `requirement_graph.py:386` via `wire_state_var_edges()`, invoked from `mcp_server.py:687` — extracts state variable references from requirement formulas
+- **`impl_block_parser.py`** → Called at `pattern_library.py:147,378` via `analyze_impl_blocks()`, used by `features/patterns.py:60` — parses implementation blocks for pattern detection
+- **`snapshots.py`** → Used by `compiler_adapter.py:174,270,299-318` — extracts module and signature snapshots from compiler state for Tier 3 enrichment
 - **All 19 LSP features**: Each has a `register()` function called from `server.py` (confirmed by grep across features/)
-- **All 15 MCP tools**: All registered via 6 modules in `tools/__init__.py` → `mcp_server.py`
+- **All 17 MCP tools**: All registered via 6 modules in `tools/__init__.py` → `mcp_server.py`
 - **All 3 CLI tools**: `ivy_check`, `ivyc`, `ivy_show` confirmed available via `ivy_capabilities`
 
-### D. MCP Tool Consolidation — Well-Executed (25→15)
+### D. MCP Tool Consolidation — Well-Executed (25→17)
 The consolidation recommended in the prior audit has been implemented:
 
 | Unified Tool | Modes/Views | Original Tools Absorbed |
@@ -132,7 +132,7 @@ Retained as independent: `ivy_verify`, `ivy_compile`, `ivy_model_info`, `ivy_dia
 See §1.3. No other formal verification tool integrates this. The system is architecturally complete: extraction → manifest → annotation → coverage → gap analysis → regression detection.
 
 ### F. Pattern Library + Scaffolding — Unique Differentiator
-- 14-layer canonical decomposition: types → frames → packets → connection → crypto → shim → behavior → monitors → properties → test_specs → application → recovery → extensions → documentation
+- 14-layer canonical decomposition: types → codec → frame → packet → connection → transport → security → application → shim → test_specs → entities → behavior → recovery → extensions
 - 7 pattern types: serdes, variants, monitors, shims, modules, entities, include-chain
 - Connected chain: `pattern_library.py` → `features/patterns.py` → MCP `ivy_patterns` tool → `ivy_pattern_scaffold` tool
 - Completeness checking: `ivy_patterns(mode="check")` scores against 14-layer template
@@ -267,13 +267,13 @@ Defines `CompiledModuleIR`, `RequirementIR`, `MixinIR`, `InvariantIR`, etc. Only
 - **`ivy-writing-guide` skill**: Covers Ivy syntax, test spec patterns, RFC bracket-tag annotations
 
 ### Could Be Optimized
-- **`methodology-reference` skill**: Covers all three methodologies (NCT + NACT + NSCT) in one document. Consider splitting into 3 focused sub-skills with a dispatcher that auto-selects based on context keywords (specification/compliance → NCT, attack/security → NACT, simulation/topology → NSCT).
+- **`methodology-reference` skill**: [RESOLVED: split into `nct-methodology`, `nact-methodology`, `nsct-methodology` in this PR] Covers all three methodologies (NCT + NACT + NSCT) in one document. Consider splitting into 3 focused sub-skills with a dispatcher that auto-selects based on context keywords (specification/compliance → NCT, attack/security → NACT, simulation/topology → NSCT).
 - **`specification-patterns` skill**: The 14-layer template is front-loaded. The "minimum viable set" (7 layers) exists but presentation buries it. Restructure to lead with quick-start path, expand to full 14 layers as needed.
 - **`workflow-reference` skill**: Overlaps with `methodology-reference` on verification workflow. Could merge verification-specific content or add clearer cross-references.
 
 ### Missing
-- **Counterexample interpretation skill**: When `ivy_verify` fails, no skill guides understanding of the structured counterexample output
-- **Incremental spec development skill**: No guided workflow for "add one requirement → verify → iterate". Current skills assume whole-file or whole-protocol scope.
+- **Counterexample interpretation skill**: [RESOLVED: `counterexample-guide` skill created in this PR] When `ivy_verify` fails, no skill guides understanding of the structured counterexample output
+- **Incremental spec development skill**: [RESOLVED: `incremental-spec-dev` skill created in this PR] No guided workflow for "add one requirement → verify → iterate". Current skills assume whole-file or whole-protocol scope.
 - **Automated review via quality tools**: `model-reviewer` agent uses manual checklist. Could integrate `ivy_quality(mode="gate")` and `ivy_patterns(mode="validate")` for semi-automated assessment with tool-backed evidence.
 
 ---
@@ -302,13 +302,13 @@ The Ivy LSP + MCP tooling is **well-positioned relative to SOTA protocol verific
 - The **only tool with specification scaffolding** (pattern library + 14-layer template)
 - The **only tool with both verification AND test generation** in one pipeline
 - **Well-wired with no dead code** (all modules connected through verified import chains)
-- **Already consolidated** (25→15 tools with clean mode-based dispatch)
+- **Already consolidated** (25→17 tools with clean mode-based dispatch)
 
 The main optimization opportunities are architectural simplification (dual graph merge, pipeline state reduction) rather than missing functionality. The highest-value gap to close is counterexample visualization, where the foundation (parser) already exists.
 
 ---
 
-## Appendix A: Post-Consolidation Tool Catalog (15 Tools)
+## Appendix A: Post-Consolidation Tool Catalog (17 Tools)
 
 | # | Tool | Modes/Params | Backend | Purpose |
 |---|---|---|---|---|
@@ -327,6 +327,8 @@ The main optimization opportunities are architectural simplification (dual graph
 | 13 | `ivy_quality` | `mode`: suggestions/gate | RequirementGraph | Quality analysis |
 | 14 | `ivy_patterns` | `mode`: analyze/validate/compare/check | RequirementGraph | Pattern analysis + scaffold checking |
 | 15 | `ivy_pattern_scaffold` | `pattern`, `protocol`, `wire_format` | Templates | Generate Ivy source from pattern |
+| 16 | `ivy_verification_dashboard` | — | Internal analyzers | Workspace-level verification status summary |
+| 17 | `ivy_generate_manifest` | `rfc_name`, `rfc_text` | Regex + YAML | Generate YAML requirement manifest from RFC text |
 
 *Note: 15 backward-compatibility aliases for the pre-consolidation tool names are also registered (see `ivy_lsp/tools/{traceability,visualization,quality,patterns}.py` — sections marked "Individual tool aliases (backward compatibility)") but not listed here.*
 
@@ -366,7 +368,7 @@ No existing tool combines all of these in a single toolchain:
 4. Formal verification of annotated properties (`ivy_verify`)
 5. Executable test generation from verified models (`ivy_compile`)
 6. Deployment-integrated conformance testing (Docker + PANTHER CI/CD)
-7. AI-accessible tooling surface (15 MCP tools) for all of the above
+7. AI-accessible tooling surface (17 MCP tools) for all of the above
 8. Full IDE-grade code intelligence (19-feature LSP)
 
 Each capability exists independently in various tools. The Ivy PANTHER ecosystem is, to our knowledge, the only system that integrates all eight in a single toolchain.

--- a/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
+++ b/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
@@ -1,0 +1,430 @@
+# Ivy Tooling Ecosystem: Strategic Evaluation & Consolidation
+
+**Date**: 2026-03-13
+**Scope**: Full strategic assessment of Ivy formal verification tooling (MCP + LSP + Claude Code integration)
+**Inputs**: Audit scorecard (25 MCP tools, 14 LSP features), state-of-the-art survey, over-engineering analysis
+**Goal**: Consolidation plan, gap analysis, and implementation roadmap
+
+---
+
+## 1. State of the Art Comparison
+
+This section compares the Ivy tooling ecosystem against established formal verification, specification management, and AI-assisted development platforms across five dimensions. Each dimension surfaces where Ivy leads, where it lags, and where consolidation would sharpen its competitive position.
+
+### Dimension 1: Code Intelligence (LSP)
+
+| Capability | Lean 4 LSP | Dafny VS Code | TLA+ Toolbox | SPARK Ada GPS | Ivy LSP |
+|------------|:----------:|:-------------:|:------------:|:-------------:|:-------:|
+| Go-to-definition | Full (cross-file, cross-import) | Full | Full | Full | Partial (cross-include works; declarations return "not found"; dotted paths fail) |
+| Find references | Full with scope awareness | Full | Find-in-project | Full with read/write distinction | Good cross-file (376 refs for `cid`); self-refs omitted; no read/write split |
+| Hover info | Type + tactic state + doc | Type + triggers + verified status | Operator definitions | Type + contracts + SPARK annotations | Nearly broken (1/6 correct); no RFC enrichment active yet |
+| Completion | Context-aware (tactics, terms) | Context-aware (keywords, ghost vars) | Action/variable names | Contracts + aspects | Keyword-only (not implemented in current LSP) |
+| Diagnostics | Real-time, per-line verification status | Real-time, error squiggles + counterexample gutter marks | Model-check error overlay | Flow analysis + runtime checks | 5-layer graduated analysis (structural, lexer, semantic, coverage, pattern) via MCP; push-based LSP diagnostics not testable |
+| Code lens | Proof state per declaration | Verify/debug lenses | N/A | Prove/examine lenses | Not implemented |
+| Code actions | Quick fixes for proof failures | Quick fixes, extract method | N/A | Refactoring, proof completion | Not implemented |
+| Rename | Full, safe | Full, safe | Basic find-replace | Full with semantic checks | Not tested (not exposed via Claude Code LSP tool); scope detection present |
+
+**Ivy LSP strengths**:
+- **3-tier graduated analysis** (structural, semantic, pattern) via `ivy_diagnostics` provides depth no other tool matches for a single diagnostics call
+- **RFC annotation enrichment** in hover (when bracket tags exist) is unique -- no other LSP ties code symbols to normative requirements
+- **Proximity-based disambiguation** in go-to-definition resolves ambiguous names using include-graph distance, handling Ivy's flat namespace without module qualifiers
+
+**Ivy LSP gaps**:
+- No interactive proof state display (Lean 4 and Dafny show tactic goals/verification status per line)
+- No verification-as-you-type (Dafny and Lean 4 verify incrementally on keystroke; Ivy requires explicit `ivy_verify` MCP call)
+- Keyword-only completion (Lean 4 and Dafny offer context-aware completions including tactic suggestions)
+- No per-line verification status gutter marks (Dafny and SPARK show green/red per declaration)
+
+### Dimension 2: Verification Integration
+
+| Capability | Dafny | Lean 4 | TLA+ Toolbox | Tamarin | ProVerif | Ivy MCP |
+|------------|:-----:|:------:|:------------:|:-------:|:--------:|:-------:|
+| Incremental verification | Yes (per-method, cached) | Yes (per-definition) | Per-model (full re-check) | Per-lemma | Full model | No (full model re-check each time) |
+| Counterexample display | Rich: variable values, execution trace, gutter marks | Tactic state at cursor | State graph + trace explorer | Attack graphs with MSC diagrams | Derivation trees | Raw text output only; no structured rendering |
+| State space exploration | Bounded model checking | Proof search tree | Explicit-state model checker with state graph | Constraint solving trace | Horn clause resolution | No exploration; binary pass/fail |
+| Verification-as-you-type | Yes (background worker, incremental) | Yes (persistent environment) | No (explicit run) | No (explicit run) | No (explicit run) | No (explicit `ivy_verify` call) |
+| Docker/container support | No (native or dotnet) | No (native) | No (native Java) | No (native) | No (native) | Yes (Docker-aware pipeline with fallback) |
+| Test binary generation | No (verified code is the artifact) | No (extracted code via tactics) | No | No | No | Yes (`ivyc target=test` produces C++ test binaries) |
+
+**Ivy strengths**:
+- **Docker-aware pipeline**: Verification, compilation, and test execution all work inside containers, enabling CI/CD integration that no other formal tool offers natively
+- **Verification + compilation + test in one toolchain**: `ivy_verify` -> `ivy_compile` -> test binary execution is a unique pipeline; other tools stop at verification or code extraction
+- **LLM can orchestrate verification via MCP**: 25 tools with typed JSON schemas let an AI agent drive the entire verification workflow -- no other formal tool has this level of programmatic access
+
+**Ivy gaps**:
+- **No incremental verification**: Every `ivy_verify` call re-checks the entire model. For QUIC (202 files), this is prohibitive for iterative development
+- **Raw text counterexamples**: When verification fails, output is unstructured text from `ivy_check`. Dafny and TLA+ render counterexamples as interactive execution traces
+- **No state space exploration**: The tool reports pass/fail but provides no mechanism to explore why a property holds or what states were checked
+
+### Dimension 3: Specification Traceability
+
+| Capability | IBM DOORS Next | Reqtify | Polarion | Ivy MCP+LSP |
+|------------|:--------------:|:-------:|:--------:|:-----------:|
+| Requirement extraction | Manual import from documents | Regex-based extraction from documents | Manual + document connectors | Automated: `ivy_extract_requirements` parses MUST/SHOULD/MAY from RFC text with sentence boundary detection (4.6/5 audit score) |
+| Annotation syntax | External linking (IDs in tool, not in code) | Pragma comments in code | External linking | Inline bracket tags `[rfc9000:4.1]` embedded directly in Ivy assertions |
+| Coverage matrix | Full bidirectional traceability matrix | Forward trace from req to test | Bidirectional with work items | `ivy_traceability_matrix` + `ivy_requirement_coverage`: functional but tag format mismatch (bare `[4]` vs `rfc9000:4.1`) currently breaks matching (0% coverage despite annotations) |
+| Gap analysis | Orphan detection both directions | Missing-link reports | Gap analysis dashboards | `ivy_coverage_gaps`: detects unguarded state variables, actions without requirement annotations, missing monitor patterns |
+| Impact analysis | Change impact via bidirectional links | File-level impact tracing | Work item dependency graph | `ivy_impact_analysis`: symbol-level impact through semantic graph edges (types, actions, relations, read/write) |
+| Integration with code | Separate from code (external tool) | Embedded pragmas, build integration | Separate tool with IDE plugins | **Native**: requirements live in the same `.ivy` files as the specification, verified by the same toolchain |
+
+**Novel contribution**: No other formal verification tool integrates requirement traceability into the specification language itself. IBM DOORS, Reqtify, and Polarion are all external tools that link to code via IDs or pragmas. Ivy's bracket-tag annotation system (`[rfc9000:4.1]`) embeds requirements directly in assertions, enabling the toolchain to verify both the formal property AND its normative coverage simultaneously.
+
+**Current limitation**: The tag format mismatch (C4 in audit backlog) means this capability is architecturally present but operationally broken. Fixing the `[N]` to `rfc9000:N` mapping would unlock what is genuinely a differentiating feature.
+
+### Dimension 4: AI-Assisted Specification
+
+| Capability | GitHub Copilot | Cursor | LLM+Lean (LeanDojo) | LLM+Coq (Proverbot9001) | Ivy MCP+Plugin |
+|------------|:--------------:|:------:|:--------------------:|:------------------------:|:--------------:|
+| Code completion | Token-level, statistical | Token + semantic (codebase RAG) | Tactic prediction | Tactic prediction | Not implemented (keyword-only LSP completion) |
+| Structured semantic access | None (text-only context) | Codebase indexing (AST-level) | Lean server API (JSON) | SerAPI (S-expressions) | **21 MCP tools** with typed JSON schemas providing symbol info, include graphs, dependency analysis, traceability matrices, pattern detection |
+| Specification generation | General code generation | General with context | Proof step generation | Proof search | `ivy_pattern_scaffold` generates complete Ivy specification templates for 5 pattern types (serdes, shim, entity, variants, monitors) with documentation |
+| Workflow guidance | None | Tab-based suggestions | None | None | 14 Claude Code skills + 9 agents with methodology knowledge (specification creation workflow, quality gates, RFC analysis) |
+| Quality enforcement | Linting only | Linting + review | Type checking | Type checking | `ivy_quality_gate` (3-tier: minimal/standard/comprehensive) + `ivy_scaffold_check` (14-layer architecture validation) + `ivy_diagnostics` (5-layer graduated analysis) |
+
+**Ivy is ahead in one critical area**: Structured semantic access for AI agents. The 21 MCP tools provide typed, queryable access to the specification model that goes far beyond what any LLM+prover integration offers. LeanDojo and Proverbot9001 give LLMs access to tactic state; Ivy gives LLMs access to the entire specification architecture (symbols, dependencies, requirements, patterns, coverage, quality metrics).
+
+**Diluted by over-proliferation**: The audit found that many tools overlap significantly (e.g., `ivy_impact_analysis` / `ivy_cross_references` / `ivy_query_symbol` query the same semantic model) and 7 visualization tools ignore their scoping parameters. Consolidation from 25 to ~12 tools would improve AI performance by reducing tool-selection confusion and ensuring each tool does one thing well.
+
+### Dimension 5: Protocol-Specific Analysis
+
+| Capability | Tamarin | ProVerif | Scyther | UPPAAL | Ivy PANTHER |
+|------------|:-------:|:--------:|:-------:|:------:|:-----------:|
+| Security property verification | Yes (Dolev-Yao, equational theories) | Yes (Horn clauses, unbounded) | Yes (bounded, automatic) | Timed automata only | Partial (safety properties, invariants, not cryptographic) |
+| Compliance testing | No (security properties only) | No (security properties only) | No (security properties only) | No (timed properties only) | **Yes**: RFC requirement-level compliance with bracket-tag traceability |
+| Attack visualization | MSC attack traces | Derivation graphs | Attack graphs | Simulation traces | Raw text only (no structured attack rendering) |
+| Test generation | No (model checking only) | No (analysis only) | No (analysis only) | Test generation from traces | **Yes**: `ivyc target=test` generates executable C++ test binaries |
+| Deployment integration | No (standalone analysis) | No (standalone analysis) | No (standalone analysis) | No (standalone analysis) | **Yes**: Docker-aware, integrated with PANTHER CI/CD pipeline, tests run against real implementations |
+| Multi-protocol | No (one model per analysis) | No (one model per analysis) | Multi-protocol (limited) | Component-based | **Yes**: QUIC, BGP, CoAP, custom protocols in unified workspace |
+
+**Ivy's niche**: Protocol compliance testing with deployment integration. Tamarin, ProVerif, and Scyther excel at cryptographic security analysis but produce no executable tests and cannot check RFC compliance. UPPAAL handles timed systems but not protocol specifications. Ivy PANTHER uniquely bridges formal specification to executable conformance testing against real protocol implementations in Docker containers.
+
+**Ivy's weakness**: Security property verification. Tamarin and ProVerif handle Dolev-Yao attackers, equational theories, and unbounded sessions -- capabilities fundamentally absent from Ivy's first-order logic framework. Ivy's `quic_attacks_stack/` models MitM scenarios but at a much coarser granularity.
+
+---
+
+## 2. Over-Engineering Assessment
+
+This section evaluates the current tooling surface for over-engineering: features that add complexity without proportional value, and identifies what to consolidate, cut, or keep.
+
+### 2.1 MCP Tool Proliferation (25 -> 12)
+
+**Problem**: 25 MCP tools cause tool-selection confusion for AI agents. The audit found:
+- 3 tools query the same semantic model with overlapping results (`ivy_impact_analysis`, `ivy_cross_references`, `ivy_query_symbol`)
+- `ivy_lint` is a strict subset of `ivy_diagnostics` (structural layer)
+- 7 visualization tools share broken `test_file` handling code
+- Several tools produce unusably large output without working scoping parameters
+
+**Consolidation table**:
+
+| Current Tool(s) | Merged Into | Rationale |
+|-----------------|-------------|-----------|
+| `ivy_lint` + `ivy_diagnostics` | **`ivy_diagnostics`** (add `layers` param) | ivy_lint is structural layer only; diagnostics is superset. Keep lint logic as fast path when `layers=["structural"]`. |
+| `ivy_impact_analysis` + `ivy_cross_references` + `ivy_query_symbol` | **`ivy_symbol_info`** | All three query the semantic graph for a symbol. Merge into one tool: symbol name -> type info + edges + references. Accept both symbol names and node_ids. |
+| `ivy_traceability_matrix` + `ivy_requirement_coverage` | **`ivy_traceability`** | Both query the same requirement manifest + annotation data. Matrix is the detail view, coverage is the summary. One tool with `detail` param. |
+| `ivy_action_requirements` + `ivy_coverage_gaps` | **`ivy_coverage`** | Both analyze action-to-requirement mapping. Action_requirements shows what's covered; coverage_gaps shows what's missing. One tool with `mode=covered|gaps|both`. |
+| `ivy_model_summary` + `ivy_layered_overview` | **`ivy_overview`** | Both produce high-level model summaries with different grouping. One tool with `group_by=file|module|layer`. |
+| `ivy_action_dependency_graph` + `ivy_state_machine_view` | **`ivy_graph`** | Both produce graph structures over actions and state. One tool with `view=dependencies|state_machine`. |
+| `ivy_scaffold_check` + `ivy_quality_gate` | **`ivy_quality`** | Scaffold_check evaluates 14-layer completeness; quality_gate checks 3-tier pass/fail. Both assess model maturity. One tool with `mode=check|gate`, `level=minimal|standard|comprehensive`. |
+| `ivy_smart_suggestions` | **Cut entirely** | All parameters ignored (1.6/5 audit score). Returns identical 114KB dump regardless of input. Resurrect only after implementing actual context-awareness. |
+| `ivy_verify` | **Keep** | Core verification, no overlap |
+| `ivy_compile` | **Keep** | Core compilation, no overlap |
+| `ivy_capabilities` | **Keep** | Environment introspection, no overlap |
+| `ivy_include_graph` | **Keep** | Unique include-chain analysis |
+| `ivy_model_info` | **Keep** | Raw `ivy_show` output, useful for debugging |
+| `ivy_extract_requirements` | **Keep** | RFC text parsing, highest audit score (4.6/5) |
+| `ivy_generate_manifest` | **Keep** | Manifest generation from RFC text |
+| `ivy_pattern_analysis` | **Keep** | Pattern detection/validation/comparison, high audit score (4.4/5) |
+| `ivy_pattern_scaffold` | **Keep** | Template generation, highest audit score (4.6/5) |
+
+**Result**: 25 tools -> 12 tools (7 merged pairs, 1 cut, 10 kept, 1 new merged tool)
+
+### 2.2 Agent Proliferation (9 -> 4)
+
+**Problem**: 9 specialized agents fragment the workflow. An LLM choosing between 9 agents faces the same combinatorial confusion as choosing between 25 tools.
+
+| Current Agents | Merged Into | Rationale |
+|----------------|-------------|-----------|
+| `spec-author`, `spec-reviewer`, `pattern-advisor` | **`specification-agent`** | All three operate on specification creation/editing. One agent with mode switching. |
+| `verification-runner`, `diagnostics-analyst` | **`verification-agent`** | Both drive verification tools and interpret results. |
+| `coverage-tracker`, `traceability-auditor` | **`compliance-agent`** | Both analyze requirement coverage and traceability. |
+| `scaffold-generator`, `quality-assessor` | **`quality-agent`** | Both evaluate and improve model quality/completeness. |
+| `workflow-orchestrator` | **Cut** | Meta-agent that dispatches to other agents; with 4 well-scoped agents, orchestration is simpler and can be handled by the primary Claude conversation. |
+
+**Result**: 9 agents -> 4 agents
+
+### 2.3 Skill Proliferation (16 -> 6)
+
+**Problem**: 16 skills create a large surface area where many skills overlap or are thin wrappers around a single MCP tool call.
+
+| Current Skills | Merged Into | Rationale |
+|----------------|-------------|-----------|
+| `create-spec`, `create-from-rfc`, `scaffold-protocol` | **`/spec-create`** | All produce new specification files. One skill with `--from-rfc`, `--from-pattern`, `--blank` flags. |
+| `run-verification`, `run-diagnostics`, `run-lint` | **`/verify`** | All invoke verification/analysis tools. One skill with `--mode verify|diagnostics|lint`. |
+| `check-coverage`, `check-traceability`, `check-quality` | **`/assess`** | All evaluate model quality from different angles. One skill combining all checks with summary. |
+| `generate-manifest`, `extract-requirements` | **`/rfc-tools`** | Both process RFC text. One skill with subcommands. |
+| `show-model`, `show-graph`, `show-overview` | **`/inspect`** | All display model information. One skill with `--view model|graph|overview|symbols`. |
+| `pattern-detect`, `pattern-scaffold` | **`/patterns`** | Both work with the pattern catalog. One skill with `--detect` and `--scaffold` modes. |
+| Remaining standalone skills | **Keep individually if distinct** | Skills that map to unique workflows (e.g., `fix-diagnostics`, `explain-error`) remain if they provide genuine multi-step orchestration. |
+
+**Result**: 16 skills -> 6 skills
+
+### 2.4 SubagentStop Quality Gates: Cut
+
+**Current behavior**: A `SubagentStop` hook kills sub-agents if quality thresholds are not met.
+
+**Cut rationale**:
+- Produces confusing UX when agents are terminated mid-task
+- Quality enforcement is better handled at the _result_ level (reject output, don't kill the worker)
+- The consolidated `ivy_quality` tool provides the same gate checks on demand
+- Agents should be allowed to complete and report, with quality issues surfaced in the response
+
+### 2.5 PreToolUse Hook: Soften to Warning
+
+**Current behavior**: A `PreToolUse` hook blocks tool calls that violate preconditions (e.g., calling `ivy_verify` without an active test file).
+
+**Soften rationale**:
+- Blocking tool calls disrupts agent workflow and produces cryptic "tool call rejected" errors
+- The underlying tools already have error handling (audit scored 3-4/5 on error handling)
+- Better approach: emit a warning in the tool response (e.g., `"warning": "No active test file set; results may be workspace-global"`) and let the agent decide
+- Keep the hook for genuinely dangerous operations (path traversal is already handled by `_validate_path`)
+
+### 2.6 Borderline (Keep but Simplify)
+
+| Component | Current State | Simplification |
+|-----------|---------------|----------------|
+| **14-layer template architecture** | Scaffold_check evaluates 14 layers (types, packet, frame, connection, crypto, shim, behavior, monitors, properties, test_specs, application, recovery, extensions, documentation). | Keep the layer model -- it's architecturally sound and unique. But simplify scoring: instead of binary present/absent per layer, add weighted scoring based on layer importance for the target protocol. Not every protocol needs all 14 layers. |
+| **Docker executor in MCP** | `ivy_compile` and `ivy_verify` spawn Docker containers when tools aren't on PATH. Silent fallback. | Keep Docker execution (it's a competitive advantage). Add `"execution_mode": "docker"|"subprocess"` to response (M2 from audit backlog). Log fallback at INFO. |
+| **Slash command routing** | 16 slash commands route to skills via Claude Code's skill system. | Reduce to 6 slash commands (matching consolidated skills). Ensure each maps to a genuine multi-step workflow, not a single tool call. |
+
+### 2.7 Well-Designed (Keep As-Is)
+
+These components scored well in the audit and represent genuine engineering value:
+
+| Component | Why Keep | Audit Evidence |
+|-----------|----------|----------------|
+| **RFC traceability system** | Unique in formal verification space. Bracket-tag annotations + manifest + coverage matrix = novel contribution. | `ivy_extract_requirements` scored 4.6/5. Architecture is sound; only tag format matching needs fixing (C4). |
+| **Semantic graph** | Powers symbol resolution, impact analysis, cross-references. Lightweight regex-based but effective for Ivy's syntax. | Correctly resolves types, actions, relations, functions. Sparse edges are a known limitation, not a design flaw. |
+| **3-tier graduated analysis** | Structural (fast, no state) -> Semantic (model-aware) -> Pattern (architecture-aware). Each layer adds cost and depth. | `ivy_diagnostics` scored 3.6/5, best in G3. 182 diagnostics for quic_frame.ivy across 5 layers shows depth. |
+| **Include resolver** | Handles Ivy's include-path-based module system with ambiguity detection and proximity ranking. | Powers go-to-definition (cross-include works), findReferences (376 results for `cid`), and the include graph. |
+| **Lazy initialization** | Semantic model, include graph, and file index built on first access, not on server startup. | Prevents 680-file indexing on cold start. Tools that don't need the semantic model don't pay for it. |
+| **PostToolUse lint hook** | Runs `ivy_lint` automatically after file modifications to catch structural errors immediately. | Fast feedback loop. Lint is cheap (sub-millisecond for structural checks). Keeps the "break early" philosophy. |
+| **SessionStart detection** | Detects workspace layout, available protocols, and tool capabilities at session start. | Provides context to agents/skills without requiring explicit initialization calls. |
+| **Path traversal protection** | `_validate_path()` uses `os.path.realpath` + prefix check. Rejects `../../../etc/passwd`. | Confirmed working in audit (security scenario 7). Correct approach. |
+
+---
+
+## 3. Missing Capabilities (Post-Consolidation)
+
+After consolidation reduces noise, these are the genuine capability gaps that, if filled, would move Ivy tooling from "useful" to "competitive with state-of-the-art."
+
+### Priority 1: Incremental Verification Feedback
+
+**Gap**: Every `ivy_verify` call re-checks the entire model. For QUIC (202 files), this means multi-minute verification cycles even for single-line changes. Lean 4 and Dafny verify incrementally per-definition.
+
+**Proposed approach**:
+- Track file modification timestamps and include-graph edges
+- On `ivy_verify`, compute the "dirty set" (modified files + their transitive dependents)
+- If dirty set is small, pass only affected isolates to `ivy_check`
+- Cache verification results keyed by file content hash + dependency hashes
+- Expose `"incremental": true|false` and `"cached_isolates": N` in response
+
+**Complexity**: High. Requires understanding Ivy's isolate boundaries and which checked properties depend on which definitions. May require cooperation with `ivy_check` itself (currently treats the model as monolithic).
+
+**Impact**: Transforms the development loop from "edit -> wait minutes -> see result" to "edit -> wait seconds -> see result." This is the single biggest productivity gap versus Lean 4 and Dafny.
+
+### Priority 2: Counterexample Rendering
+
+**Gap**: When `ivy_verify` fails, the output is raw `ivy_check` text. Dafny shows variable values at each step; TLA+ shows a state graph; Tamarin shows MSC attack traces.
+
+**Proposed approach**:
+- Parse `ivy_check` failure output to extract: failing property, counterexample trace (variable assignments per step), and the violated invariant
+- Structure as JSON: `{"property": "...", "trace": [{"step": 1, "state": {"var": "val", ...}}, ...], "violated_invariant": "..."}`
+- For protocol-specific rendering: map state variables to protocol concepts (e.g., `stream_seen` -> "Stream X is in state Y")
+- Optionally generate Mermaid sequence diagrams for protocol traces
+
+**Complexity**: Medium. `ivy_check` output format is semi-structured. Parsing requires pattern matching but not compiler-level analysis.
+
+**Impact**: Makes verification failures actionable. Currently, an LLM receiving raw counterexample text must guess at the structure. Structured traces let the agent explain failures and suggest fixes.
+
+### Priority 3: Coverage Regression Detection
+
+**Gap**: No mechanism detects when code changes reduce requirement coverage. The `ivy_traceability` tools report current coverage but don't compare against a baseline.
+
+**Proposed approach**:
+- Store coverage snapshots as JSON baselines (per-protocol, per-commit)
+- On `ivy_coverage --mode=regression`, diff current coverage against baseline
+- Report: newly uncovered requirements, newly covered requirements, coverage delta percentage
+- Integrate with PANTHER CI/CD: fail the pipeline if coverage drops below threshold
+
+**Complexity**: Low-medium. Coverage computation already exists. The addition is baseline storage and diffing.
+
+**Impact**: Prevents silent requirement de-coverage during model evolution. Essential for any project using Ivy for compliance testing.
+
+### Priority 4: Guided Spec Creation Wizard
+
+**Gap**: Creating a new protocol specification requires knowing the 14-layer architecture, naming conventions, include patterns, and requirement annotation syntax. Currently, `ivy_pattern_scaffold` generates individual files but doesn't orchestrate the full creation workflow.
+
+**Proposed approach**:
+- Interactive multi-step workflow (via Claude Code skill):
+  1. Input: protocol name, RFC document(s), target layers
+  2. Extract requirements from RFC (`ivy_extract_requirements`)
+  3. Generate manifest (`ivy_generate_manifest`)
+  4. Scaffold each requested layer (`ivy_pattern_scaffold`)
+  5. Run quality gate (`ivy_quality` in `gate` mode)
+  6. Report: created files, coverage baseline, next steps
+- Store the result as a new protocol directory with proper structure
+
+**Complexity**: Medium. All building blocks exist. The addition is orchestration logic and state management across steps.
+
+**Impact**: Lowers the barrier to entry for new protocol models. Currently requires deep Ivy expertise; the wizard would make it accessible to protocol engineers who know their RFC but not Ivy syntax.
+
+---
+
+## 4. Implementation Roadmap
+
+### Phase 1: Consolidation (2-3 weeks)
+
+| Step | Action | Files Affected | Risk |
+|------|--------|----------------|------|
+| 1 | **Merge `ivy_lint` into `ivy_diagnostics`**: Add `layers` parameter. When `layers=["structural"]`, use fast path. Deprecate `ivy_lint` tool registration. | `tools/verification.py`, `tools/analysis.py`, `mcp_server.py` | Low. Lint logic already exists in diagnostics structural layer. |
+| 2 | **Merge semantic query tools**: Combine `ivy_impact_analysis` + `ivy_cross_references` + `ivy_query_symbol` into `ivy_symbol_info`. Accept both symbol names and node_ids. Return unified response with type info, edges, and references. | `tools/traceability.py`, `tools/analysis.py`, `mcp_server.py` | Medium. Three different response schemas must be unified. |
+| 3 | **Merge traceability tools**: Combine `ivy_traceability_matrix` + `ivy_requirement_coverage` into `ivy_traceability` with `detail` parameter. | `tools/traceability.py` | Low. Both already query the same data. |
+| 4 | **Merge visualization tools**: Combine overlapping pairs (`action_requirements`+`coverage_gaps`, `model_summary`+`layered_overview`, `dependency_graph`+`state_machine_view`). Cut `ivy_smart_suggestions`. Fix `test_file` filtering for all remaining tools. | `tools/visualization.py`, `features/visualization.py` | High. 7 tools with shared broken code. Fix the filtering first, then merge. |
+| 5 | **Merge quality tools**: Combine `ivy_scaffold_check` + `ivy_quality_gate` into `ivy_quality`. | `tools/quality.py`, `features/quality_gates.py` | Low. Distinct logic, just needs unified entry point. |
+
+### Phase 2: Gap Filling (3-4 weeks)
+
+| Step | Action | Dependencies | Risk |
+|------|--------|--------------|------|
+| 6 | **Fix critical bugs (C1-C8)**: Workspace root misconfiguration, `test_file` parameter ignored, tag format mismatch, include graph path mismatch, hover broken, workspaceSymbol unfiltered, `file_path` returns empty, `includes_resolve` always fails. | Phase 1 Step 4 fixes C2/C3. Others are independent. | Medium. C1 and C5 require path normalization changes that could break existing users. |
+| 7 | **Implement counterexample rendering (Priority 2)**: Parse `ivy_check` failure output into structured JSON. | Independent of Phase 1. | Medium. Output format parsing is fragile. |
+| 8 | **Implement coverage regression detection (Priority 3)**: Baseline storage, diffing, CI integration. | Phase 1 Step 3 (merged traceability tool). | Low. Incremental addition to existing coverage logic. |
+
+### Phase 3: Design Document (1 week)
+
+| Step | Action | Dependencies |
+|------|--------|--------------|
+| 9 | **Write strategic evaluation document** (this document). Produce consolidated architecture diagram, updated tool catalog, and handoff notes for incremental verification (Priority 1) and guided spec wizard (Priority 4) as future work. | Phases 1-2 for validation data. |
+
+### Timeline Summary
+
+```
+Week 1-2:  Phase 1 Steps 1-3 (low-risk merges)
+Week 2-3:  Phase 1 Steps 4-5 (visualization merge + quality merge)
+Week 3-5:  Phase 2 Step 6 (critical bug fixes, parallelizable with Step 5)
+Week 5-6:  Phase 2 Steps 7-8 (counterexample rendering + coverage regression)
+Week 7:    Phase 3 Step 9 (this document finalized, architecture review)
+```
+
+---
+
+## 5. Verification Checklist
+
+### After Phase 1 (Consolidation)
+
+- [ ] Tool count reduced from 25 to 12 (verify with `ivy_capabilities`)
+- [ ] All deprecated tool names return a helpful deprecation message pointing to the replacement
+- [ ] `ivy_diagnostics` with `layers=["structural"]` produces identical output to old `ivy_lint`
+- [ ] `ivy_symbol_info` with symbol name returns type info + edges (formerly 3 separate calls)
+- [ ] `ivy_traceability` with `detail=true` returns full matrix; `detail=false` returns coverage summary
+- [ ] `ivy_coverage` with `mode=covered` matches old `ivy_action_requirements`; `mode=gaps` matches old `ivy_coverage_gaps`
+- [ ] `ivy_overview` with `group_by=file` matches old `ivy_model_summary`; `group_by=layer` matches old `ivy_layered_overview`
+- [ ] `ivy_graph` with `view=dependencies` matches old `ivy_action_dependency_graph`; `view=state_machine` matches old `ivy_state_machine_view`
+- [ ] `ivy_quality` with `mode=check` matches old `ivy_scaffold_check`; `mode=gate` matches old `ivy_quality_gate`
+- [ ] `ivy_smart_suggestions` is removed; no tool registered under that name
+- [ ] All 12 remaining tools have working `protocol` parameter for scoping
+- [ ] All visualization tools correctly filter by `test_file` when provided
+- [ ] Output size for QUIC full model < 100KB for any single tool call (relative paths, proper scoping)
+- [ ] Existing test suite passes (adjust for new tool names)
+- [ ] Claude Code plugin configuration updated: 6 skills, 4 agents
+
+### After Phase 2 (Gap Filling)
+
+- [ ] C1 fixed: `ivy_verify`/`ivy_compile`/`ivy_lint`/`ivy_model_info` resolve paths with `protocol-testing/` prefix fallback; error messages include resolved absolute path
+- [ ] C4 fixed: `ivy_traceability` correctly maps bare numeric bracket tags `[N]` to manifest requirement IDs `rfc9000:N`; QUIC coverage > 0%
+- [ ] C5 fixed: `ivy_include_graph` path keys normalized; individual file queries return non-empty `includes` list
+- [ ] C6 fixed: LSP hover returns correct info for at least 4/6 original test scenarios
+- [ ] C7 fixed: LSP workspaceSymbol filters results by query text
+- [ ] H8 fixed: `ivy_quality` gate `includes_resolve` exempts known Ivy stdlib modules; QUIC passes `minimal` gate
+- [ ] H10 fixed: Dotted names (`frame.stream.handle`) resolve correctly in `ivy_symbol_info`
+- [ ] Counterexample rendering: `ivy_verify` failure response includes `"counterexample": {"trace": [...], "violated_property": "..."}` when available
+- [ ] Coverage regression: `ivy_traceability --mode=regression --baseline=<path>` correctly reports coverage delta
+- [ ] No regressions in audit scores: re-run audit scenarios for merged tools, all scores >= original tool scores
+
+---
+
+## Appendix A: Current Tool Inventory (Pre-Consolidation)
+
+For reference, the full list of 25 MCP tools with their audit scores and consolidation target:
+
+| # | Current Tool | Avg Score | Group | Consolidation Target |
+|---|-------------|:---------:|:-----:|---------------------|
+| 1 | ivy_lint | 2.0 | G1 | Merge into `ivy_diagnostics` |
+| 2 | ivy_verify | 2.0 | G1 | **Keep** |
+| 3 | ivy_compile | 2.0 | G1 | **Keep** |
+| 4 | ivy_model_info | 2.2 | G1 | **Keep** |
+| 5 | ivy_capabilities | 3.2 | G2 | **Keep** |
+| 6 | ivy_include_graph | 2.4 | G2 | **Keep** |
+| 7 | ivy_diagnostics | 3.6 | G3 | **Keep** (absorbs ivy_lint) |
+| 8 | ivy_traceability_matrix | 2.4 | G4 | Merge into `ivy_traceability` |
+| 9 | ivy_requirement_coverage | 2.6 | G4 | Merge into `ivy_traceability` |
+| 10 | ivy_impact_analysis | 2.8 | G4 | Merge into `ivy_symbol_info` |
+| 11 | ivy_extract_requirements | 4.6 | G4 | **Keep** |
+| 12 | ivy_generate_manifest | 3.8 | G4 | **Keep** |
+| 13 | ivy_cross_references | 2.4 | G4 | Merge into `ivy_symbol_info` |
+| 14 | ivy_query_symbol | 3.2 | G4 | Merge into `ivy_symbol_info` |
+| 15 | ivy_action_requirements | 2.6 | G5 | Merge into `ivy_coverage` |
+| 16 | ivy_model_summary | 2.6 | G5 | Merge into `ivy_overview` |
+| 17 | ivy_coverage_gaps | 2.2 | G5 | Merge into `ivy_coverage` |
+| 18 | ivy_action_dependency_graph | 2.6 | G5 | Merge into `ivy_graph` |
+| 19 | ivy_state_machine_view | 3.2 | G5 | Merge into `ivy_graph` |
+| 20 | ivy_layered_overview | 2.8 | G5 | Merge into `ivy_overview` |
+| 21 | ivy_smart_suggestions | 1.6 | G5 | **Cut** |
+| 22 | ivy_pattern_analysis | 4.4 | G6 | **Keep** |
+| 23 | ivy_pattern_scaffold | 4.6 | G6 | **Keep** |
+| 24 | ivy_scaffold_check | 4.4 | G6 | Merge into `ivy_quality` |
+| 25 | ivy_quality_gate | 4.2 | G6 | Merge into `ivy_quality` |
+
+## Appendix B: Post-Consolidation Tool Catalog (12 Tools)
+
+| # | Tool | Source(s) | Key Parameters | Purpose |
+|---|------|-----------|----------------|---------|
+| 1 | `ivy_verify` | Keep | `file_path`, `isolate`, `timeout` | Run formal verification via `ivy_check` |
+| 2 | `ivy_compile` | Keep | `file_path`, `target`, `timeout` | Compile Ivy model to C++ test binary |
+| 3 | `ivy_model_info` | Keep | `file_path`, `isolate` | Raw `ivy_show` model structure output |
+| 4 | `ivy_capabilities` | Keep | (none) | Report available tools, versions, Docker status |
+| 5 | `ivy_include_graph` | Keep | `file_path`, `protocol`, `max_depth` | Include chain analysis with transitive closure |
+| 6 | `ivy_diagnostics` | Keep + ivy_lint | `file_path`, `protocol`, `layers[]`, `min_severity` | Graduated 5-layer analysis |
+| 7 | `ivy_symbol_info` | impact_analysis + cross_references + query_symbol | `symbol`, `node_id`, `protocol` | Unified symbol lookup: type info + edges + references |
+| 8 | `ivy_traceability` | traceability_matrix + requirement_coverage | `protocol`, `scope_file`, `detail`, `mode` | Requirement coverage matrix and summary |
+| 9 | `ivy_coverage` | action_requirements + coverage_gaps | `protocol`, `scope_file`, `mode` | Action-to-requirement mapping (covered/gaps/both) |
+| 10 | `ivy_overview` | model_summary + layered_overview | `protocol`, `scope_file`, `group_by` | High-level model structure view |
+| 11 | `ivy_graph` | action_dependency_graph + state_machine_view | `protocol`, `scope_file`, `view`, `include_state_vars`, `state_var_filter` | Dependency and state machine graph views |
+| 12 | `ivy_quality` | scaffold_check + quality_gate | `protocol`, `mode`, `level` | Model maturity assessment (check/gate) |
+
+Plus 5 standalone tools kept as-is:
+- `ivy_extract_requirements` (4.6/5)
+- `ivy_generate_manifest` (3.8/5)
+- `ivy_pattern_analysis` (4.4/5)
+- `ivy_pattern_scaffold` (4.6/5)
+
+**Total**: 12 merged/kept + 5 standalone = 17. Further consolidation of the 5 standalone tools is not recommended as they each serve distinct, high-scoring functions.
+
+*Correction*: The 5 standalone tools are counted within the 12 above. The final tool count is **12** unique tools total (7 merged entries + 5 kept as-is = 12, after cutting `ivy_smart_suggestions` and absorbing `ivy_lint`).
+
+---
+
+## Appendix C: Comparison with Prior Art in Combined Verification+Traceability
+
+No existing tool combines:
+1. Formal protocol specification language
+2. Automated RFC requirement extraction
+3. Inline requirement annotation in specifications
+4. Formal verification of annotated properties
+5. Executable test generation from verified models
+6. Deployment-integrated conformance testing
+7. AI-accessible tooling surface (MCP) for all of the above
+
+Each capability exists independently in various tools (Dafny for #1/#4, DOORS for #2/#3, Tamarin for #1/#4, PANTHER for #5/#6, LeanDojo for #7). The Ivy PANTHER ecosystem is, to our knowledge, the only system that integrates all seven in a single toolchain.
+
+The consolidation proposed in this document does not reduce this capability set. It reduces the _surface area_ through which these capabilities are accessed, making the system easier to use for both human engineers and AI agents.

--- a/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
+++ b/docs/superpowers/specs/2026-03-13-ivy-tooling-evaluation.md
@@ -328,7 +328,7 @@ The main optimization opportunities are architectural simplification (dual graph
 | 14 | `ivy_patterns` | `mode`: analyze/validate/compare/check | RequirementGraph | Pattern analysis + scaffold checking |
 | 15 | `ivy_pattern_scaffold` | `pattern`, `protocol`, `wire_format` | Templates | Generate Ivy source from pattern |
 
-*Note: 15 backward-compatibility aliases for the pre-consolidation tool names are also registered but not listed here.*
+*Note: 15 backward-compatibility aliases for the pre-consolidation tool names are also registered (see `ivy_lsp/tools/{traceability,visualization,quality,patterns}.py` — sections marked "Individual tool aliases (backward compatibility)") but not listed here.*
 
 ## Appendix B: LSP Feature Registration (19 Features)
 

--- a/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
+++ b/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
@@ -5,11 +5,20 @@
 **Scope**: Full-stack validation of ivy-lsp indexing + panther-ivy-plugin integration
 **Audience**: Dual-purpose — engineering assessment (6-month POC guide) + academic framing (P6 Ivy LSP Tool Paper, AMC3 WP2 deliverables)
 
+**Prior work this document builds on**:
+- `2026-03-13-ivy-tooling-audit-results.md` — 25-tool quality audit (8 critical issues C1-C8)
+- `2026-03-16-lsp-mcp-correctness-audit-results.md` — 45-validation correctness audit (FM-D, coverage inflation, semantic graph broken)
+- `2026-03-16-ivy-plugin-evaluation-results.md` — 65-test plugin evaluation (72% pass rate)
+- `2026-03-17-sota-evaluation-panther-ivy-plugin.md` — SOTA alignment (91.7%, 8 properties at 2/3)
+- `2026-03-17-requirement-coverage-redesign.md` — 7-problem coverage redesign (4 phases)
+- `2026-03-18-lsp-performance-pipeline-enablers.md` — Pipeline enabler plan (Tasks 1-7, **executed**)
+- `2026-03-18-ivy-lsp-indexing-improvements-design.md` — 3-workstream improvement design
+
 ---
 
 ## 1. Context
 
-The PANTHER/ivy-lsp/panther-ivy-plugin stack implements an "endpoint-mirror-as-workspace" model for NCT (Network-Centric Compositional Testing). In this model, each master test file (e.g., `quic_client_test.ivy`) defines a complete workspace partition via its transitive include closure. The ivy-lsp server indexes this workspace, and the panther-ivy-plugin exposes it to Claude Code via MCP tools, hooks, skills, and agents.
+The PANTHER/ivy-lsp/panther-ivy-plugin stack implements an "endpoint-mirror-as-workspace" model for NCT (Network-Centric Compositional Testing). Each master test file (e.g., `quic_client_test.ivy`) defines a complete workspace partition via its transitive include closure. The ivy-lsp server indexes this workspace, and the panther-ivy-plugin exposes it to Claude Code via MCP tools, hooks, skills, and agents.
 
 Before AMC3 WP2's 6-month POC sprint (Feb-Aug 2026), this document validates whether:
 1. The workspace model is conceptually sound and faithfully implemented
@@ -26,94 +35,80 @@ This feeds into P6 (Ivy LSP Tool Paper, TACAS/FSE 2027) and P3 (Agent-Driven Evi
 
 **Verdict: Sound, with two documented caveats.**
 
-The model treats each test entry point as defining a complete workspace partition. This mirrors what `ivyc` sees when compiling that test — the compiler resolves includes from a flat directory and builds only the reachable graph.
+The model treats each test entry point as defining a complete workspace partition. This mirrors what `ivyc` sees when compiling that test.
 
 **Evidence of correctness**:
-- `_compute_test_scopes()` (`workspace_indexer.py:1324`) walks files with exports, computes transitive closure via `IncludeGraph.get_transitive_includes()`, and registers a `TestScope` with `include_closure` (FrozenSet), `exported_actions`, `imported_actions`, and `tester_role`
-- Role detection in `detect_test_role()` (`test_scope.py:75`) implements Ivy's role inversion by checking for `server_behavior`/`client_behavior` basename patterns in the include closure
-- The `test_file` parameter in coverage tools filters requirements to `scope.include_closure`, matching exactly the files PANTHER copies into the Docker staging directory
+- `_compute_test_scopes()` (`workspace_indexer.py`) walks files with exports, computes transitive closure via `IncludeGraph.get_transitive_includes()`, and registers a `TestScope` with `include_closure` (FrozenSet), `exported_actions`, `imported_actions`, and `tester_role`
+- Role detection in `detect_test_role()` (`test_scope.py`) implements Ivy's role inversion
+- `test_file` parameter in coverage tools filters requirements to `scope.include_closure`, matching the files PANTHER copies into the Docker staging directory
 
-**Caveat 1 — Basename collision semantics**: The flat symlink staging (`create_staging_directory()`, `include_resolver.py:223`) mirrors `ivyc`'s CWD-relative resolution. When two test scopes need different files sharing a basename, partitioned staging via graph coloring (`build_partitioned_staging()`) handles this. The greedy graph coloring is correct (produces optimal partitions when the conflict graph is a tree). Complexity is O(T x B x V) where T=test scopes, B=colliding basenames, V=variants per basename. For the QUIC workspace (~200 files, ~30 collisions, ~20 test scopes), this is negligible.
+**Caveat 1 — Basename collision semantics**: Flat symlink staging mirrors `ivyc`'s CWD-relative resolution. Partitioned staging via graph coloring handles conflicts. O(T x B x V) complexity — negligible for QUIC (~200 files, ~30 collisions, ~20 test scopes).
 
-**Caveat 2 — No cross-scope invariant checking**: Each test scope is treated independently. No mechanism verifies that shared files (e.g., `quic_connection.ivy` included by both client and server tests) maintain consistent assume-guarantee contracts across scopes. Theoretically safe by Ivy's compositionality guarantee, but not surfaced as a verifiable property.
+**Caveat 2 — No cross-scope invariant checking**: Each test scope is independent. Shared files maintain assume-guarantee contracts by Ivy's compositionality, but not surfaced as verifiable.
 
 ### 2.2 Layer-by-Layer Assessment
 
-#### Layer 1: Workspace Detection (`workspace_detection.py`, 321 lines) — Adequate
+#### Layer 1: Workspace Detection (`workspace_detection.py`, ~320 lines) — Adequate
 
-**Implementation**: 6-strategy priority chain: explicit > hint > walk-up `.ivyworkspace` marker > walk-down marker > PANTHER heuristic > git worktree > fallback. The v2 `.ivyworkspace` schema supports `include_paths`, `exclude_paths`, `scope_detection`, `standard_library`, `project_type`.
+**Implementation**: 6-strategy priority chain with v2 `.ivyworkspace` schema.
 
-**Edge cases**:
-- Multiple `.ivyworkspace` in walk-down: returns FIRST found at any depth, not closest
-- `max_depth=10` in walk-up prevents infinite loops but could miss very deep markers
-- PANTHER heuristic false-positive: any dir with `protocol-testing/` + `panther_ivy.py`
+**Edge cases**: Walk-down returns FIRST marker, not closest. PANTHER heuristic could false-positive.
 
-**Gap**: No multi-root workspace support (LSP 3.6 `workspace/didChangeWorkspaceFolders`).
+**Gap**: No multi-root workspace (LSP 3.6). No `.ivyworkspace` v3 with `workspace_layers` for APT separation.
 
-#### Layer 2: Include Resolution (`include_resolver.py`, 552 lines) — Novel, Strong
+#### Layer 2: Include Resolution (`include_resolver.py`, ~550 lines) — Novel, Strong
 
-**Implementation**: 4-step resolution chain (same dir > staging > workspace root > stdlib). Staging creates flat symlinks to all `.ivy` files, with first-sorted-path-wins collision handling. Partitioned staging via graph coloring for multi-test isolation.
+**Implementation**: 4-step resolution chain. Flat symlink staging. Partitioned staging via graph coloring.
 
-**Critical finding — ivyc divergence**: ivyc uses `open(name + '.ivy')` in CWD (2-step: CWD then stdlib). The LSP uses 4-step with staging as bridge. Step 3 (workspace root) is extra and could resolve files ivyc wouldn't find.
+**Critical finding — ivyc divergence**: LSP step 3 (workspace root) is extra — could resolve files ivyc wouldn't.
 
-**Known bug — Errno 17**: `build_partitioned_staging()` at line 446 calls `os.symlink()` without `os.path.lexists()` guard, producing `[Errno 17] File exists` errors. The main `create_staging_directory()` has this guard (line 265) but the partitioned variant does not.
+**Known bug — Errno 17**: `build_partitioned_staging()` line 446 calls `os.symlink()` without `os.path.lexists()` guard. Main staging has this guard but partitioned variant does not.
 
-**Edge cases**:
-- ~50 basename collisions between APT and standard models (e.g., `ivy_quic_client.ivy` in both `quic/` and `apt/quic/`) — `.ivyworkspace` v2 `include_paths: ["protocol-testing"]` includes both
-- ~30 additional collisions within QUIC (e.g., `byte_stream.ivy` 3x, `file.ivy` 3x)
-- Dynamic file additions after staging creation miss new files until re-index
-- No VFS abstraction — raw symlink management with no atomic refresh, reference counting, or lifecycle encapsulation
+**Known bug — `os.path.exists()` vs `lexists()`**: Main staging at line 265 uses `exists`, not `lexists` — misses dangling symlinks.
 
-**Gaps**: (a) Collisions logged but not surfaced as LSP diagnostics. (b) Errno 17 bug in partitioned staging. (c) No VFS abstraction layer. (d) APT/standard workspace separation needed (v3 schema).
+**Edge cases**: ~50 APT/standard collisions + ~30 intra-QUIC collisions. No VFS abstraction.
 
-#### Layer 3: Two-Phase Indexing (`workspace_indexer.py`, ~1400 lines) — Good Tradeoff
+**Gaps**: (a) Collisions not surfaced as diagnostics. (b) Errno 17 bug. (c) No VFS abstraction. (d) APT/standard separation needed (v3 schema).
 
-**Implementation**: Phase 1 = fast lexer scan via regex/PLY (1-3s for 202 QUIC files, immediate LSP readiness). Phase 2 = background full parse from test entry points (files with exports, ~40 in QUIC, 10-30s). Thread-safe symbol swapping under `_table_lock` with atomic reference swap for concurrent reads.
+#### Layer 3: Two-Phase Indexing (`workspace_indexer.py`, ~1370 lines) — Good Tradeoff
 
-**Edge cases**:
-- Phase 2 interruption gracefully degrades to Phase 1 quality
-- Phase 2 removes Phase 1 requirements before adding full ones — mid-failure leaves gaps (caught by error handler)
-- `_source_cache` thread safety relies on Python GIL (safe but implicit)
+**Implementation**: Phase 1 = fast lexer scan (1-3s). Phase 2 = background full parse from test entry points (10-30s). Thread-safe symbol swapping.
 
-**Gap**: No incremental per-declaration re-indexing. Full re-index per file change.
+**Recently completed**: `SymbolTable.remove_file()` (P1, commit `8241397`) and selective mirror-scope cache invalidation (P2, commit `fa45f92`) already implemented via pipeline enablers plan. Demand-driven deep parse for shared modules (P4, commit `f639105`) also complete.
 
-#### Layer 4: Test Scope Model (`test_scope.py`, 328 lines) — Novel, Strong
+**Remaining gap**: No incremental per-declaration re-indexing. No viewport-aware priority queue for Phase 2.
 
-**Implementation**: `TestScope` frozen dataclass with `include_closure` (FrozenSet), `exported_actions`, `imported_actions`, `tester_role`. `ScopedRequirementModel` extends `RequirementGraph` with per-test caching and proper invalidation. NCT classification: `_generating` -> TESTER_ONLY, `after/around` mixin -> GUARANTEE, `ensure/assert` -> GUARANTEE, else ASSUMPTION.
+#### Layer 4: Test Scope Model (`test_scope.py`, ~328 lines) — Novel, Strong
 
-**Quantitative**: ~40 test files, each closure 15-40 files. O(T x C) ~ 1000 graph lookups — fast.
-
-**Edge cases**:
-- Phantom test scope: shared behavior files with `export` create their own scope
-- Role detection heuristic fails for protocols not using `server_behavior`/`client_behavior` naming
-- `_generating` detection is string match in `formula_text` — reliable for Ivy convention but fragile if text unavailable
+**Implementation**: `TestScope` frozen dataclass. `ScopedRequirementModel` with per-test caching. NCT classification: `_generating` -> TESTER_ONLY, `after/around` -> GUARANTEE, `ensure/assert` -> GUARANTEE, else ASSUMPTION.
 
 **Gap**: No cross-scope invariant checking.
 
-#### Layer 5: Semantic Model (`analysis_pipeline.py` ~1000 lines, `model.py` 296 lines) — Adequate
+#### Layer 5: Semantic Model (`analysis_pipeline.py` ~940 lines, `model.py` ~295 lines) — Adequate
 
-**Implementation**: T1 (<50ms, syntactic, RFC annotation parsing), T2 (<200ms, AST-enriched), T3 (background compiler). Thread-safe `SemanticModel` with RLock, tier-aware updates (higher overwrites lower). Generation tracking for stale T3 result rejection.
+**Implementation**: T1 (<50ms), T2 (<200ms), T3 (background). Thread-safe with RLock and generation tracking.
 
-**Gap**: No per-position semantic data (Lean 4 InfoTree equivalent).
+**Known bug — semantic graph non-functional** (03-16 audit): `ivy_impact_analysis`, `ivy_cross_references`, and `ivy_action_dependency_graph` all return empty edge lists. The MCP semantic model builds nodes but never computes edges. LSP `findReferences` works (1404 references for `cid`), proving data exists but MCP layer doesn't use it.
+
+**Gap**: No per-position semantic data (Lean 4 InfoTree equivalent). Empty semantic graph edges.
 
 #### Layer 6: MCP Tools (`tools/`, 6 modules, ~130KB) — Novel, Strong
 
-**Implementation**: 34 registered `@mcp.tool()` functions — **15 primary tools + 19 legacy aliases** (per indexing-improvements audit). `test_file` scoping correctly implements endpoint-mirror: `abs_test = ctx.validate_path(test_file)` -> `scope = graph.get_test_scope(abs_test)` -> filter to `scope.include_closure`. Path traversal prevention. Lazy model construction with async lock and 30s cooldown.
+**Implementation**: 33 registered `@mcp.tool()` functions — **18 primary tools + 15 legacy aliases**. `test_file` scoping correctly implements endpoint-mirror. Path traversal prevention. Lazy model construction.
 
-**Edge cases**:
-- MCP standalone vs LSP mode model divergence (different code paths)
-- If `test_file` not yet indexed, fallback filters to just the test file itself, losing scope
-- `ivy_quality(mode="suggestions")` `_resolve_scope` does not derive testFile from filePath (P8 bug)
+**Recently fixed**: `ivy_quality(mode="suggestions")` context scoping (P8, commit `6f4b504`).
 
-**Gaps**: (a) 19 legacy aliases bloat prompt ~56% (34->15 after removal, per arXiv:2510.14537 tool taxonomy research). (b) No CC evidence export format. (c) No taxonomy-based categorization for 6-category LLM tool selection guidance.
+**Known bug — FM-D diagnostic parsing** (03-16 audit, top critical): `parse_ivy_output()` fails on absolute paths in MCP staging mode, causing `ivy_verify`, `ivy_compile`, `ivy_model_info` to return `diagnostics=[]` when errors exist. Structured diagnostics silently dropped.
+
+**Known bug — coverage inflation** (03-16 audit, 03-17 coverage redesign): Bare `# [N]` tags on struct fields are false-positive matched to `rfc9000:N.*` requirements. Coverage stats and gaps tools disagree by 21 requirements. See `2026-03-17-requirement-coverage-redesign.md` for the 7-problem analysis and 4-phase fix design.
+
+**Gaps**: (a) 15 legacy aliases bloat prompt ~45% (33->18 after removal). (b) No CC evidence export. (c) No taxonomy categorization. (d) FM-D diagnostic parsing. (e) Coverage correctness (7 problems per redesign spec).
 
 #### Layer 7: Plugin Integration (`panther-ivy-plugin`) — Novel Architecture
 
-**Implementation**: 10 hook points, 15 observability scripts, `block-direct-ivy.sh` PreToolUse enforcement, `lint-before-verify.sh` PostToolUse auto-lint. `/nct-validate` with 55 checks across 7 phases. 4 agents (spec-analyst, methodology-guide, model-reviewer, traceability-agent), 11 skills, 9 commands.
+**Implementation**: 10 hook points, 15 observability scripts, CLI enforcement, auto-lint. 4 agents, 11 skills, 9 commands. `/nct-validate` with 55 checks.
 
-**Edge cases**:
-- Hook timeout (2-10s) — large logs cause silent timeout
-- `${CLAUDE_PLUGIN_ROOT}` must be correctly set by Claude Code
+**SOTA gaps at 2/3** (per 03-17 evaluation): A1 (verify loop guided but not enforced), A2 (error categorization incomplete), A3 (cross-references broken), A4 (file-level caching only, no per-isolate).
 
 **Gap**: No iterative verification skill, no LLM diff-checker.
 
@@ -124,9 +119,9 @@ The model treats each test entry point as defining a complete workspace partitio
 | Approach | Verdict | Reasoning |
 |----------|---------|-----------|
 | **Endpoint-mirror (current)** | **Keep** | NCT-aligned, matches PANTHER runtime, enables per-test coverage |
-| Module-based (Lean 4 style) | Incompatible | Ivy `include` is textual inclusion (like C `#include`), not module import — would require language changes |
-| Project-wide | Loses NCT alignment | Can't answer "which tests cover this requirement?" Cross-protocol pollution |
-| On-demand/lazy (Coq Fleche) | Incompatible with agent workflow | Agent needs workspace-wide views (coverage matrices); lazy indexing would materialize views per query |
+| Module-based (Lean 4 style) | Incompatible | Ivy `include` is textual inclusion — would require language changes |
+| Project-wide | Loses NCT alignment | Can't answer "which tests cover this requirement?" |
+| On-demand/lazy (Coq Fleche) | Incompatible with agent workflow | Agent needs workspace-wide views |
 
 #### Include Resolution
 
@@ -134,85 +129,114 @@ The model treats each test entry point as defining a complete workspace partitio
 |----------|---------|-----------|
 | **Flat symlink staging (current)** | **Keep** | Faithful to ivyc, manageable complexity |
 | FUSE/overlay FS | Reject | macOS FUSE deprecated, Linux needs container privileges |
-| Rewrite-based | Reject | Changes file semantics, breaks ivyc compilation |
-| Compiler-integrated | Reject (hybrid possible) | ivyc global state, subprocess per include too slow. Use T3 to validate T2 resolution as hybrid. |
+| Rewrite-based | Reject | Changes file semantics, breaks ivyc |
+| Compiler-integrated | Reject (hybrid possible) | Use T3 to validate T2 resolution |
 
 #### Indexing Strategy
 
 | Approach | Verdict | Reasoning |
 |----------|---------|-----------|
-| **Two-phase lexer+parser (current)** | **Keep** | Best latency/correctness tradeoff for agent workflow |
+| **Two-phase lexer+parser (current)** | **Keep** | Best latency/correctness tradeoff |
 | Single-phase full parse | Reject | 30-60s startup blocks agent |
-| Incremental per-declaration | Future enhancement | Requires tree-sitter or custom parser — major effort |
+| Incremental per-declaration | Future enhancement | Requires tree-sitter or custom parser |
 | Demand-driven | Reject | First coverage query triggers full parse anyway |
 
 #### MCP Tool Design
 
 | Approach | Verdict | Reasoning |
 |----------|---------|-----------|
-| **Mode-based consolidation (15 tools)** | **Keep** | Sweet spot of discoverability vs context efficiency (~1500 tokens) |
-| One-tool-per-operation (30+) | Reject | ~3000 tokens overhead, agent may choose wrong tool |
-| GraphQL-style single query | Reject | Shifts complexity to query construction, opaque errors |
+| **Mode-based consolidation (18 tools)** | **Keep** | Sweet spot of discoverability vs context efficiency |
+| One-tool-per-operation (30+) | Reject | Context overhead, wrong tool selection |
+| GraphQL-style single query | Reject | Shifts complexity to query construction |
 
 #### Plugin Architecture
 
 | Approach | Verdict | Reasoning |
 |----------|---------|-----------|
-| **Full plugin (skills + agents + hooks + commands)** | **Keep** | Essential enforcement and guidance for agent workflow |
-| Pure-MCP (tools only) | Loses enforcement | No hooks, no agents, no skills, no observability |
-| IDE extension (VS Code) | Complementary | No agent enforcement, no MCP access — targets humans, not AI |
+| **Full plugin (skills + agents + hooks + commands)** | **Keep** | Essential enforcement and guidance |
+| Pure-MCP (tools only) | Loses enforcement | No hooks, agents, skills, observability |
+| IDE extension (VS Code) | Complementary | Targets humans, not AI agents |
 
 ### 2.4 Threats to Validity
 
 | # | Threat | Prob | Severity | Mitigation In Place | Mitigation Needed |
 |---|--------|------|----------|---------------------|-------------------|
-| T1 | Basename collision -> wrong include resolution | MED | HIGH | Collision map, partitioned staging with graph coloring | Validate staging vs ivyc per test file (F5) |
+| T1 | Basename collision -> wrong include | MED | HIGH | Collision map, partitioned staging | Conformance tests (F5) |
 | T2 | Phase 1 regex misses includes | LOW | MED | Regex covers all standard Ivy; Phase 2 validates | None |
-| T3 | NCT classification incorrectness | MED | HIGH | Tested in `test_nct_classification.py`; `_generating` is reliable Ivy convention | Cross-validate against manual annotation |
-| T4 | MCP/LSP semantic model divergence | MED | MED | `build_semantic_model` shared code | Add test comparing both models |
-| T5 | Role detection heuristic brittleness | LOW (QUIC), HIGH (new protocols) | MED | Returns "unknown" when no heuristic matches | Explicit role annotation support |
-| T6 | Single-protocol evaluation | HIGH | MED | QUIC only | Demonstrate on CoAP by P6 submission |
-| T7 | Ground truth staleness | MED | MED | nct-validate checks 55 items | Automated ground truth from ivyc (I4) |
-| T8 | Std lib version mismatch | MED | MED | LSP selects highest version; ivyc selects lowest >= language version — different! | Fix LSP to match ivyc selection logic |
-| T9 | Agent context window saturation | HIGH | MED | Skills on demand; CLAUDE.md single page; mode consolidation | Token budget tracking |
+| T3 | NCT classification incorrectness | MED | HIGH | Tested; `_generating` is reliable convention | Cross-validate against manual annotation |
+| T4 | MCP/LSP semantic model divergence | MED | MED | Shared `build_semantic_model` | Add comparison test |
+| T5 | Role detection heuristic brittleness | LOW/HIGH | MED | Returns "unknown" when no match | Explicit role annotation |
+| T6 | Single-protocol evaluation | HIGH | MED | QUIC only | Demonstrate on CoAP by P6 |
+| T7 | Ground truth staleness | MED | MED | nct-validate 55 checks | Automated ground truth (I4) |
+| T8 | Std lib version mismatch | MED | MED | LSP selects highest; ivyc selects lowest >= lang version | Fix LSP algorithm (F6) |
+| T9 | Context window saturation | HIGH | MED | Skills on demand; mode consolidation | Token budget tracking |
 | T10 | Observability event-loss | LOW | LOW | `atexit` handlers | Event-loss detection (D5) |
+| T11 | Coverage inflation (NEW) | HIGH | HIGH | None | Tag disambiguation (coverage redesign Phase 1) |
+| T12 | FM-D diagnostic parsing (NEW) | HIGH | HIGH | Errors in `raw_output` field | Fix `parse_ivy_output()` absolute path handling |
 
 ### 2.5 Related Work Comparison
 
 | System | Language | Scoping | Incremental | MCP/Agent | RFC Traceability | CC Evidence |
 |--------|----------|---------|-------------|-----------|------------------|-------------|
-| **ivy-lsp** | Ivy 1.7 | Endpoint-mirror | Per-file | 15 MCP + 4 agents | Bracket tags + manifests | Planned |
+| **ivy-lsp** | Ivy 1.7 | Endpoint-mirror | Per-file | 18 MCP + 4 agents | Bracket tags + manifests | Planned |
 | Lean 4 LSP | Lean 4 | Module | Per-declaration | No | N/A | No |
 | Coq Fleche | Coq | Document | Per-sentence | No | N/A | No |
 | DafnyPro | Dafny | Function | No | No | N/A | No |
 | lean-lsp-mcp | Lean 4 | Module | Reuses Lean | MCP wrapper (5 tools) | N/A | No |
 | SpecGen | Multiple | N/A | N/A | LLM loop | N/A | No |
 
-**Key differentiators**:
-- **vs Lean 4 LSP**: Finer granularity (per-declaration vs per-file) but no MCP, hooks, agent coordination, or RFC traceability. Per-declaration snapshots are gold standard for incrementality.
-- **vs Coq Fleche**: Viewport-following incompatible with MCP-first agent workflow. Per-sentence caching could inspire per-action caching.
-- **vs DafnyPro**: 86% correct proofs with Claude 3.5. Evaluation methodology (iterations-to-fix, per-complexity success rates) should inform P6. Fully automated loop vs our "guided convergence."
-- **vs lean-lsp-mcp**: Same MCP-wrapped-LSP pattern but 5 thin wrappers vs 15 deep-integrated tools. No traceability, quality gates, or visualization.
-- **vs SpecGen**: Mutation-based repair (syntactic) vs counterexample-guided repair (semantic). No traceability.
+**Key differentiators**: See prior version for full comparison prose (vs Lean 4, Coq Fleche, DafnyPro, lean-lsp-mcp, SpecGen).
+
+### 2.6 Known Bug Index
+
+Cross-reference of unfixed bugs from prior audits with roadmap items or status:
+
+| Bug ID | Source | Description | Status / Roadmap Item |
+|--------|--------|-------------|----------------------|
+| C1 | 03-13 audit | Workspace root misconfiguration (path without `protocol-testing/` prefix) | Partially mitigated by `validate_path` fallback |
+| C2 | 03-13 audit | `test_file` ignored on all visualization tools | **Fixed** (mode-based consolidation + scoping) |
+| C3 | 03-13 audit | `ivy_smart_suggestions` all params ignored | **Fixed** (P8, commit `6f4b504`) |
+| C4 | 03-13 audit | 0% coverage despite annotations (tag format mismatch) | Coverage redesign Phase 1 |
+| C5 | 03-13 audit | `ivy_include_graph` path key mismatch | **Fixed** (normalize graph keys) |
+| C6 | 03-13 audit | hover nearly broken | **Partially fixed** (03-16 work); hover text duplication remains |
+| C7 | 03-13 audit | workspaceSymbol no filtering | **Fixed** (scope-ranking, commit series) |
+| C8 | 03-13 audit | `ivy_action_requirements` file_path empty | **Fixed** (consolidated into `ivy_model_summary`) |
+| FM-D | 03-16 audit | Diagnostic parsing broken on absolute paths | **Unfixed** — D2 partially addresses; needs dedicated fix (T12) |
+| FM-B | 03-16 audit | Cross-workspace symbol disambiguation | APT workspace separation (D4) |
+| -- | 03-16 audit | Semantic graph edges all empty | **Unfixed** — needs dedicated fix (D6) |
+| -- | 03-16 audit | Coverage stats/gaps disagree by 21 reqs | Coverage redesign Phase 1 |
+| -- | 03-16 audit | Scaffold checker false negatives | **Unfixed** — low priority |
+| P1-P7 | 03-17 coverage redesign | 7 coverage correctness problems | Coverage redesign Phases 1-4 |
 
 ---
 
 ## 3. Improvement Roadmap
 
+### Completed Work (Pipeline Enablers Plan, executed)
+
+The following items from `2026-03-18-lsp-performance-pipeline-enablers.md` are already implemented:
+
+| Task | Description | Commit |
+|------|-------------|--------|
+| P1 | `SymbolTable.remove_file()` in-place removal | `8241397` |
+| P2 | Mirror-scope selective cache invalidation | `fa45f92` |
+| P4 | Demand-driven deep parse for shared modules | `f639105` |
+| P8 | `ivy_quality` context scoping fix | `6f4b504` |
+
 ### Phase 0: Immediate — Remove Legacy Debt & Fix Bugs
 
-#### F0a: Remove 19 Legacy MCP Tool Aliases (34 -> 15 tools)
+#### F0a: Remove 15 Legacy MCP Tool Aliases (33 -> 18 tools)
 
-**Problem**: 19 backward-compatibility `@mcp.tool()` aliases duplicate the 15 primary consolidated tools. They bloat the MCP prompt ~56% and confuse tool selection. Plugin docs already use consolidated names only.
+**Problem**: 15 backward-compatibility `@mcp.tool()` aliases duplicate the 18 primary consolidated tools. They bloat the MCP prompt ~45% and confuse tool selection. Plugin docs already use consolidated names only (verified by `test_documentation.py`).
 
-**Aliases to delete** (4 files):
+**Aliases to delete** (4 files, 33 total registrations -> 18 after removal):
 
-| Module | Aliases | Lines |
-|--------|---------|-------|
-| `traceability.py` | `ivy_requirement_coverage`, `ivy_coverage_gaps`, `ivy_traceability_matrix`, `ivy_query_symbol`, `ivy_impact_analysis`, `ivy_cross_references`, `ivy_generate_manifest` | 1241-1294 |
-| `visualization.py` | `ivy_action_dependency_graph`, `ivy_state_machine_view`, `ivy_layered_overview`, `ivy_action_requirements` | 313-342 |
-| `patterns.py` | `ivy_pattern_analysis`, `ivy_scaffold_check` | 282-297 |
-| `quality.py` | `ivy_smart_suggestions`, `ivy_quality_gate` | 368-383 |
+| Module | Current Count | Aliases to Delete | After |
+|--------|--------------|-------------------|-------|
+| `traceability.py` | 11 | `ivy_requirement_coverage`, `ivy_coverage_gaps`, `ivy_traceability_matrix`, `ivy_query_symbol`, `ivy_impact_analysis`, `ivy_cross_references`, `ivy_generate_manifest` (7) | 4 |
+| `visualization.py` | 6 | `ivy_action_dependency_graph`, `ivy_state_machine_view`, `ivy_layered_overview`, `ivy_action_requirements` (4) | 2 |
+| `patterns.py` | 4 | `ivy_pattern_analysis`, `ivy_scaffold_check` (2) | 2 |
+| `quality.py` | 3 | `ivy_smart_suggestions`, `ivy_quality_gate` (2) | 1 |
 
 **Verification**: `pytest tests/`, `/nct-validate` (update tool count ground truth), `/nct-health`.
 
@@ -220,152 +244,147 @@ The model treats each test entry point as defining a complete workspace partitio
 
 #### F0b: Fix Errno 17 Symlink Bug
 
-`build_partitioned_staging()` at `include_resolver.py:446` — add `if os.path.lexists(link_path): os.unlink(link_path)` before `os.symlink()`. Add startup cleanup for stale `ivy-lsp-stage-*` dirs.
+`build_partitioned_staging()` at `include_resolver.py:446` — add `if os.path.lexists(link_path): os.unlink(link_path)` before `os.symlink()`. Also fix main staging to use `lexists` instead of `exists` (line 265) to catch dangling symlinks. Add startup cleanup for stale `ivy-lsp-stage-*` dirs.
 
 **Effort**: 1 hour.
 
-#### F0c: Fix ivy_quality Context Scoping (P8)
+#### F0c: Fix FM-D Diagnostic Parsing (T12)
 
-`_resolve_scope` in `visualization.py` — when testFile is None and filePath is provided, derive scope via `graph.get_tests_for_file(file_path)`.
+`parse_ivy_output()` fails on absolute paths in MCP staging mode. `ivy_verify`, `ivy_compile`, `ivy_model_info` return `diagnostics=[]` silently. Fix regex to handle absolute paths.
 
-**Effort**: 2 hours.
-
-#### F0d: Demand-Driven Deep Parse for Shared Modules (P4)
-
-Add `deep_parse_on_demand(filepath)` to `WorkspaceIndexer`. Wire into hover, goto-def, and document-symbols handlers. Shared libraries get AST-quality symbols on first interaction.
-
-**Effort**: 1-2 days.
+**Effort**: 2-3 hours.
 
 ---
 
 ### Phase 1: Foundation (Months 1-2) — LSP Core + LLM Safety
 
-#### F1: Incremental Per-File Re-Indexing
+#### F1: Coverage Correctness (Tag Disambiguation + Manifest Validation)
 
-**Problem**: `_remove_file_symbols()` rebuilds entire SymbolTable by copying all symbols except target — O(n) for 10,000+ symbols. `_compute_test_scopes()` clears all 200+ cache entries on every single-file reindex.
+**Problem**: 7 coverage problems identified in `2026-03-17-requirement-coverage-redesign.md`. False-positive bare numeric tags inflate coverage. Orphan detection inconsistent. Missing manifest = silent zero.
 
-**Changes**:
-1. `symbols.py` — Add `SymbolTable.remove_file(filepath) -> int` using in-place `_by_file.pop()` + prune `_by_name`/`_all`. O(k) vs O(n).
-2. `workspace_indexer.py:1091-1099` — Replace body with `self._symbol_table.remove_file(filepath)`.
-3. `workspace_indexer.py:1324` — `_compute_test_scopes(dirty_files=None)`. When provided, only invalidate cache entries whose `include_closure` intersects `dirty_files`.
-4. Wire: `reindex_file()` -> `_compute_test_scopes(dirty_files={abs_path})`.
+**Changes**: Implement Phases 1-2 of the coverage redesign:
+- Phase 1a: Filter false-positive bare numeric tags in `parse_file_rfc_annotations()`
+- Phase 1b: Align orphan detection with coverage computation
+- Phase 1c: Manifest field validation
+- Phase 1d: Missing manifest warning
+- Phase 1e: Ambiguous tag warning
+- Phase 2: RFC fetcher + section-aware parser
 
-**Example**: Editing `quic_connection.ivy` — before: rebuild 10,000+ symbols, clear 200+ caches. After: remove ~50 symbols, clear ~12 affected caches.
-
-**Effort**: 2-3 weeks. **Enables**: D3, D4. **Impact**: P6 + P3.
+**Effort**: 3 weeks. **Impact**: P6 (credible coverage data for paper), P3 (CC evidence accuracy).
 
 #### F2: Basename Collision Diagnostics
 
-**Changes**:
-1. `diagnostics.py` — New `_emit_collision_diagnostics()` emitting Warning on ambiguous `include` statements.
-2. `analysis.py` — Add `collisions` field to `ivy_include_graph` response.
-3. `include_resolver.py` — Add `get_collision_report() -> dict`.
+Surface collision map as LSP Warning diagnostics + `collisions` field in `ivy_include_graph` response.
 
 **Effort**: 1 week. **Impact**: P6.
 
 #### F3: LLM Diff-Checker Hook
 
-**Changes**:
-1. `hooks.json` — New PreToolUse hook for `Write|Edit` running `check-base-spec-guard.sh`.
-2. `.ivyworkspace` — `frozen_files: ["quic_stack/quic_types.ivy", "tls_stack/*.ivy"]`.
-3. New `check-base-spec-guard.sh` (~40 lines) — Parse TOOL_USE_INPUT, check against frozen list.
-
-**Minimal**: Glob matching. **Full**: `/nct-freeze`/`/nct-unfreeze` + auto-freeze.
+PreToolUse hook for `Write|Edit` with `frozen_files` in `.ivyworkspace`.
 
 **Effort**: 2 weeks. **Impact**: P3 (gatekeeper).
 
 #### F4: Iterative Verification Skill
 
-**Changes**: New `skills/iterative-verification/SKILL.md` — CEGAR loop:
-1. `ivy_lint` (max 3 syntax retries)
-2. `ivy_verify(isolate=X)` — if counterexample, go to 3
-3. Diagnose via `counterexample-guide`
-4. Apply single fix
-5. Re-lint, re-verify (back to 1)
-6. Termination: pass OR iterations > 5
-7. Output: structured log per iteration
+New `skills/iterative-verification/SKILL.md` — CEGAR loop with structured iteration logging. Addresses SOTA property A1 (verify loop enforcement).
 
-**Example**: rfc9000:4.1 in `quic_server_test_stream.ivy` — lint (pass) -> verify (counterexample: `stream_state=idle`) -> fix (`require stream_state = open`) -> re-verify (pass). 2 iterations.
-
-**Effort**: 2 weeks. **Impact**: P3 (core loop).
+**Effort**: 2 weeks. **Impact**: P3 (core loop), SOTA A1.
 
 #### F5: Conformance Tests Against ivyc
 
-**Changes**: New `tests/conformance/` — compare LSP's `TestScope.include_closure` against `ivyc` actual resolution. `@pytest.mark.requires_ivy` skip when ivyc unavailable.
+New `tests/conformance/` — compare LSP include closure against `ivyc` actual resolution.
 
 **Effort**: 1 week. **Impact**: P6 (threat T1 mitigation).
+
+#### F6: Fix Std Lib Version Selection (T8)
+
+Fix `_get_std_include_dir` in `include_resolver.py` to match ivyc's algorithm: select lowest version >= language version, not highest.
+
+**Effort**: 2 hours. **Impact**: T8 mitigation.
 
 ### Phase 2: Depth & Trust (Months 3-4) — CC Evidence + Verification Loop
 
 #### D1: CC Evidence Export
 
-**New MCP tool**: `ivy_cc_evidence(mode="adv_fsp"|"ate_fun"|"ava_van"|"ate_cov"|"full")`.
+New MCP tool `ivy_cc_evidence(mode="adv_fsp"|"ate_fun"|"ava_van"|"ate_cov"|"full")`.
 
-| CC Family | Sub-Component | ivy-lsp Artifact |
-|-----------|---------------|------------------|
-| ADV_FSP.1-2 | Basic/security-enforcing spec | Exported action signatures + `require` guards |
-| ADV_FSP.3-4 | Complete with state model | State var read/write edges |
-| ADV_FSP.5-6 | Semi-formal/formal with correspondence | Ivy source + bracket tags + Z3 proofs |
-| ATE_FUN.1-2 | Functional/ordered testing | Per-isolate verdicts + 14-layer dependency graph |
-| AVA_VAN.1-5 | Vulnerability analysis (levels) | NACT error injection/mutation results |
-| ATE_COV.1-3 | Coverage (levels) | Requirement coverage per test scope |
+| CC Family | ivy-lsp Artifact |
+|-----------|------------------|
+| ADV_FSP.1-6 | Exported actions + guards + state model + Ivy source + Z3 proofs |
+| ATE_FUN.1-2 | Per-isolate verdicts + 14-layer dependency graph |
+| AVA_VAN.1-5 | NACT error injection/mutation results |
+| ATE_COV.1-3 | Requirement coverage per test scope |
 
 **Effort**: 3-4 weeks. **Impact**: P3 (flagship), WP2 D2.3.
 
 #### D2: Verification Failure Repair Hints
 
-**Changes**: `verification.py` — Add `error_category` and `repair_hints` to `ivy_verify` response:
-- `safety_violation` -> suggest `require {var} = {expected_value}`
-- `type_error` -> suggest type correction
-- `timeout` -> suggest `attribute {isolate}.timeout = 60`
+Add `error_category` enum and `repair_hints` to `ivy_verify` response. Addresses SOTA property A2.
 
-**Effort**: 3 weeks. **Impact**: P3 + P6.
+**Effort**: 3 weeks. **Impact**: P3 + P6, SOTA A2.
 
 #### D3: Snapshot-Based Incremental Model Updates
 
-**Changes**: `requirement_graph.py` — `update_file_requirements()` for incremental re-wire. `workspace_indexer.py` — use incremental update in `reindex_file()`. Content hash tracking for skip-if-unchanged.
+Incremental `requirement_graph.update_file()` + content hash tracking.
 
-**Benchmark**: Full wire ~100ms -> incremental ~5ms per file.
+**Effort**: 4 weeks. **Impact**: P6.
 
-**Effort**: 4 weeks. **Requires**: F1. **Impact**: P6.
+#### D4: APT Workspace Separation (`.ivyworkspace` v3)
 
-#### D4: Multi-Root Workspace Support
+`.ivyworkspace` v3 schema with `workspace_layers` (per indexing-improvements WS3-3.1). Eliminates ~50 APT/standard collisions at source. Per-layer staging directories.
 
-**Changes**: `workspace_indexer.py` — `add_workspace_folder()`/`remove_workspace_folder()`. `server.py` — handle `workspace/didChangeWorkspaceFolders`. `.ivyworkspace` — `roots: [...]`.
-
-**Effort**: 3 weeks. **Impact**: P6.
+**Effort**: 3 weeks. **Impact**: P6, T1 mitigation.
 
 #### D5: Observability Event-Loss Detection
 
-**Changes**: SessionStart initializes monotonic counter. Each hook increments and logs sequence number. Stop hook compares vs expected, reports gaps.
+Monotonic event counter + sequence numbering + gap detection at Stop.
 
 **Effort**: 1 week. **Impact**: P3.
+
+#### D6: Fix Semantic Graph Edge Computation (NEW)
+
+The MCP semantic model builds nodes but never computes edges. `ivy_impact_analysis`, `ivy_cross_references`, `ivy_action_dependency_graph` return empty results. LSP `findReferences` proves the data exists. Bridge LSP reference data into MCP semantic model. Addresses SOTA property A3.
+
+**Effort**: 2-3 weeks. **Impact**: P6 (visualization tools), SOTA A3.
 
 ### Phase 3: Integration & Demo (Months 5-6) — Polish
 
 #### I1: LSIF Export
 
-New `ivy_lsp/lsif/exporter.py` (LSIF 0.4). MCP tool `ivy_lsif_export()`. CLI `--lsif-dump`.
+New `ivy_lsp/lsif/exporter.py` (LSIF 0.4). MCP tool + CLI.
 
 **Effort**: 3 weeks. **Impact**: P6 (artifact).
 
 #### I2: End-to-End Demo
 
-Scripted: lint -> verify (counterexample) -> fix -> re-verify (pass) -> coverage -> quality gate -> CC evidence. New `/nct-demo` command.
+Scripted: lint -> verify -> fix -> re-verify -> coverage -> quality gate -> CC evidence. New `/nct-demo` command.
 
 **Effort**: 2 weeks. **Impact**: P3 + WP2.
 
 #### I3: Paper Evaluation Infrastructure
 
-New `evaluation/` with latency/accuracy/convergence benchmarks. See RQ1-RQ4 in Section 4.
+New `evaluation/` with latency/accuracy/convergence benchmarks. See RQ1-RQ4.
 
-**Effort**: 3 weeks. **Impact**: P6 (evaluation section).
+**Effort**: 3 weeks. **Impact**: P6.
 
 #### I4: Automated Ground Truth from ivyc
 
-Script that captures ivyc include resolution per test entry point, generates `quic-workspace.yaml`. CI integration.
+Script that captures ivyc include resolution, generates `quic-workspace.yaml`. CI integration.
 
 **Effort**: 1 week. **Impact**: P6 + nct-validate.
+
+### Deferred / Out of Scope for 6-Month POC
+
+| Item | Source | Reason |
+|------|--------|--------|
+| VFS abstraction layer (`IvyVFS` protocol) | Indexing improvements WS1-1.2 | Major refactor; Errno 17 fix (F0b) is sufficient for POC |
+| Viewport-aware indexing priority queue | Indexing improvements WS1-1.3 | Demand-driven deep parse (P4, done) covers the primary use case |
+| Qualified includes proposal (`include quic.quic_types`) | Indexing improvements WS3-3.2 | Academic/long-term; doesn't affect POC pipeline |
+| Tool taxonomy categorization (6 categories) | Indexing improvements WS2-2.2 | Nice-to-have; CLAUDE.md already provides structured guidance |
+| Per-isolate verification caching (SOTA A4) | SOTA eval | Significant effort; file-level caching adequate for POC |
+| Scaffold presets (P3) | Pipeline enablers Task 5 | Plugin UX improvement, not on critical path |
+| Skill prerequisites frontmatter (P13) | Pipeline enablers Task 6 | Plugin UX improvement, not on critical path |
+| Coverage redesign Phases 3-4 (lifecycle, multi-protocol) | Coverage redesign | Phase 1-2 sufficient for POC; Phases 3-4 are post-POC |
 
 ---
 
@@ -377,7 +396,7 @@ Script that captures ivyc include resolution per test entry point, generates `qu
 - Compare `ivy_coverage(mode="stats")` globally vs per `test_file`
 - Metrics: false positive rate, phantom coverage inflation
 - Expected: Project-wide inflates by 10-20% due to cross-scope tag bleeding
-- Ground truth: Manual verification of 20 random requirements
+- Ground truth: Manual verification of 30 random requirements (from 97 total in `rfc9000_requirements.yaml`)
 
 **RQ2: LSP response latency across workspace sizes**
 - Synthetic workspaces: 10, 50, 100, 200, 500 files
@@ -385,38 +404,39 @@ Script that captures ivyc include resolution per test entry point, generates `qu
 - Report p50/p95/p99 for each tool
 
 **RQ3: Agent verification loop effectiveness (F4)**
-- 20 QUIC MUST requirements not yet formalized
+- 30 QUIC MUST requirements not yet formalized
 - Metrics: iterations-to-fix, success rate, time-to-fix, manual intervention rate
 - Expected: lint first-pass 85-90%, verify first-pass 40-60%, mean iterations 2-4, 75-85% within 5
 - Comparison: DafnyPro's 2.3 mean iterations (POPL 2026)
 
 **RQ4: Requirement extraction accuracy**
-- Compare `ivy_extract_requirements` vs manual `rfc9000_requirements.yaml` (90 reqs)
+- Compare `ivy_extract_requirements` vs manual `rfc9000_requirements.yaml` (97 reqs)
 - Metrics: precision (60-70%), recall (70-80%), F1, level accuracy (90%+)
+- Note: Must run AFTER F1 (tag disambiguation) to avoid false-positive inflation
 
 ### 4.2 Novelty Claims
 
-1. **Endpoint-mirror workspace partitioning** — No prior art for test-entry-point-based workspace scoping in formal LSPs. Closest: contract-based hardware verification but not LSP-integrated.
+1. **Endpoint-mirror workspace partitioning** — No prior art for test-entry-point-based workspace scoping in formal LSPs.
    - *Objection*: "QUIC-specific." *Response*: 14 layers map to general protocol engineering concepts.
 
-2. **Flat-symlink staging with graph-coloring partition isolation** — Novel for languages with CWD-relative includes.
-   - *Objection*: "Why not fix the language?" *Response*: Ivy is maintained by Microsoft Research; we build on top.
+2. **Flat-symlink staging with graph-coloring partition isolation** — Novel for flat-include languages.
+   - *Objection*: "Why not fix the language?" *Response*: Ivy is maintained by Microsoft Research.
 
-3. **Three-tier progressive analysis pipeline** — T1<50ms, T2<200ms, T3 background.
-   - *Objection*: "Lean 4 does this better." *Response*: Per-file is appropriate for Ivy's smaller workspaces.
+3. **Three-tier progressive analysis for flat-include languages** — T1<50ms, T2<200ms, T3 background. The unique constraint: include graph must be materialized before semantic analysis can begin (no hierarchical module system to guide ordering).
+   - *Objection*: "Lean 4 does this better." *Response*: Lean 4's per-declaration model assumes hierarchical modules. Our flat-include constraint makes the problem fundamentally different.
 
-4. **MCP-wrapped formal verification with RFC traceability** — 15 tools with bracket tags, coverage matrices, quality gates.
-   - *Objection*: "lean-lsp-mcp also wraps LSP." *Response*: 5 thin wrappers vs 15 deep-integrated tools.
+4. **MCP-wrapped formal verification with RFC traceability** — 18 tools with bracket tags, coverage matrices, quality gates.
+   - *Objection*: "lean-lsp-mcp also wraps LSP." *Response*: 5 thin wrappers vs 18 deep-integrated tools with traceability.
 
-5. **Agent-as-a-Guide for CC evidence** — No published work automates the full CC pipeline from formal specs.
-   - *Objection*: "Engineering, not research." *Response*: Novel architectural patterns for safety-critical applications.
+5. **Agent-as-a-Guide for CC evidence** — First system to compose LSP + MCP + agent hooks to produce CC-compliant evidence chains from formal specifications.
+   - *Objection*: "Engineering, not research." *Response*: The gatekeeper pattern (untrusted LLM -> LSP+Ivy -> trusted human) with observability analytics is a novel architectural contribution for safety-critical systems.
 
 ### 4.3 WP2 Deliverable Mapping
 
 | Deliverable | What ivy-lsp Provides | Roadmap Items |
 |-------------|----------------------|---------------|
 | D2.1: Agent Architecture | "Agent-as-a-Guide" spec | F3, F4 |
-| D2.2: Tool Integration | MCP API, hooks, observability | F2, D5 |
+| D2.2: Tool Integration | MCP API, hooks, observability | F0a, F2, D5 |
 | D2.3: Evidence Generation | CC evidence (ADV_FSP + ATE_FUN + AVA_VAN + ATE_COV) | D1 |
 | D2.4: Evaluation | Benchmarks (RQ1-RQ4), iteration metrics | I2, I3 |
 
@@ -432,21 +452,12 @@ TSF Interface: quic_connection.open
   Verification: PASS (Z3, 2.3s, no counterexample)
 ```
 
-**ATE_FUN evidence format** (per verified isolate):
-```
-Test Case: quic_server_test_stream/stream_send_isolate
-  SFR Traced: rfc9000:4.1, rfc9000:8.1
-  Verdict: PASS
-  Z3 Time: 2.3s
-  Dependencies: quic_types, quic_frame, quic_packet
-```
-
 **ATE_COV evidence format** (per test scope):
 ```
 Protocol: QUIC (RFC 9000)
-  Total MUST: 52, Covered: 47 (90.4%)
-  Uncovered: [rfc9000:17.2.3, rfc9000:17.2.5, rfc9000:19.5, rfc9000:21.1, rfc9000:21.2]
-  Delta: +3 newly covered since last assessment
+  Total MUST: 45, Covered: 42 (93.3%)
+  Manifest: rfc9000_requirements.yaml (97 requirements)
+  Uncovered: [rfc9000:17.2.3, rfc9000:17.2.5, rfc9000:19.5]
 ```
 
 ---
@@ -455,20 +466,18 @@ Protocol: QUIC (RFC 9000)
 
 | File | Purpose | Roadmap Items |
 |------|---------|---------------|
-| `ivy_lsp/tools/traceability.py` | MCP coverage/requirements + 7 legacy aliases | **F0a**, D1, I4 |
-| `ivy_lsp/tools/visualization.py` | MCP visualization + 4 legacy aliases + `_resolve_scope` | **F0a**, **F0c** |
+| `ivy_lsp/tools/traceability.py` | MCP coverage/requirements + 7 legacy aliases | **F0a**, F1, D1, I4 |
+| `ivy_lsp/tools/visualization.py` | MCP visualization + 4 legacy aliases | **F0a** |
 | `ivy_lsp/tools/patterns.py` | MCP patterns + 2 legacy aliases | **F0a** |
 | `ivy_lsp/tools/quality.py` | MCP quality + 2 legacy aliases | **F0a** |
-| `ivy_lsp/indexer/include_resolver.py` | Include resolution, staging, Errno 17 bug | **F0b**, F2, F5, T8 |
-| `ivy_lsp/indexer/workspace_indexer.py` | Central indexer, deep_parse_on_demand | **F0d**, F1, D3, D4 |
-| `ivy_lsp/features/hover.py` | Hover — wire demand-driven deep parse | **F0d** |
-| `ivy_lsp/features/definition.py` | Goto-def — wire demand-driven deep parse | **F0d** |
-| `ivy_lsp/features/document_symbols.py` | Outline — wire demand-driven deep parse | **F0d** |
+| `ivy_lsp/tools/verification.py` | ivy_verify, diagnostic parsing | **F0c**, D2, F4 |
+| `ivy_lsp/indexer/include_resolver.py` | Include resolution, staging, Errno 17 | **F0b**, F2, F5, F6, T8 |
+| `ivy_lsp/indexer/workspace_indexer.py` | Central indexer | D3, D4 |
+| `ivy_lsp/semantic/rfc_annotations.py` | Tag parsing, coverage computation | F1 (coverage correctness) |
+| `ivy_lsp/features/visualization.py` | `_resolve_scope`, smart_suggestions | Already fixed (P8) |
 | `ivy_lsp/analysis/test_scope.py` | NCT test scope model | Core novelty |
 | `ivy_lsp/workspace_detection.py` | Workspace auto-detection | D4 |
-| `ivy_lsp/semantic/analysis_pipeline.py` | 3-tier progressive analysis | D3 |
-| `ivy_lsp/tools/verification.py` | ivy_verify, error parsing | D2, F4 |
+| `ivy_lsp/semantic/analysis_pipeline.py` | 3-tier progressive analysis | D3, D6 |
 | `panther-ivy-plugin/hooks/hooks.json` | Hook definitions | F3, D5 |
-| `panther-ivy-plugin/CLAUDE.md` | Operating guide | All |
-| `panther_ivy/ivy_command_mixin.py` | PANTHER workspace init | F5 validation |
-| `.ivyworkspace` | Workspace config (v2) | F3, D4 |
+| `panther-ivy-plugin/CLAUDE.md` | Operating guide | F0a (update tool refs) |
+| `.ivyworkspace` | Workspace config (v2, upgrade to v3) | F3, D4 |

--- a/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
+++ b/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
@@ -119,7 +119,7 @@ The model treats each test entry point as defining a complete workspace partitio
 | Approach | Verdict | Reasoning |
 |----------|---------|-----------|
 | **Endpoint-mirror (current)** | **Keep** | NCT-aligned, matches PANTHER runtime, enables per-test coverage |
-| Module-based (Lean 4 style) | Incompatible | Ivy `include` is textual inclusion — would require language changes |
+| Module-based (Lean 4 style) | Incompatible (LSP-only prototype feasible) | Ivy `include` is textual inclusion — language changes needed. An LSP-only qualified-include layer (see indexing-improvements WS3-3.2) could provide module-like scoping without changing Ivy itself. |
 | Project-wide | Loses NCT alignment | Can't answer "which tests cover this requirement?" |
 | On-demand/lazy (Coq Fleche) | Incompatible with agent workflow | Agent needs workspace-wide views |
 
@@ -173,6 +173,8 @@ The model treats each test entry point as defining a complete workspace partitio
 | T10 | Observability event-loss | LOW | LOW | `atexit` handlers | Event-loss detection (D5) |
 | T11 | Coverage inflation (NEW) | HIGH | HIGH | None | Tag disambiguation (coverage redesign Phase 1) |
 | T12 | FM-D diagnostic parsing (NEW) | HIGH | HIGH | Errors in `raw_output` field | Fix `parse_ivy_output()` absolute path handling |
+| T13 | Dynamic/conditional includes | LOW | LOW | Ivy syntax does not support parameterized includes | Document as N/A assumption; verify if any Ivy extensions exist |
+| T14 | Single-evaluator bias | MED | MED | None | Second evaluator for RQ1 ground truth and RQ3 manual assessments |
 
 ### 2.5 Related Work Comparison
 
@@ -396,7 +398,7 @@ Script that captures ivyc include resolution, generates `quic-workspace.yaml`. C
 - Compare `ivy_coverage(mode="stats")` globally vs per `test_file`
 - Metrics: false positive rate, phantom coverage inflation
 - Expected: Project-wide inflates by 10-20% due to cross-scope tag bleeding
-- Ground truth: Manual verification of 30 random requirements (from 97 total in `rfc9000_requirements.yaml`)
+- Ground truth: Stratified manual verification of 50 requirements (from 97 total in `rfc9000_requirements.yaml`), with second evaluator for inter-rater reliability (T14)
 
 **RQ2: LSP response latency across workspace sizes**
 - Synthetic workspaces: 10, 50, 100, 200, 500 files

--- a/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
+++ b/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
@@ -1,0 +1,425 @@
+# NCT Workspace Model Validation & Improvement Roadmap
+
+**Date**: 2026-03-18
+**Status**: Draft
+**Scope**: Full-stack validation of ivy-lsp indexing + panther-ivy-plugin integration
+**Audience**: Dual-purpose — engineering assessment (6-month POC guide) + academic framing (P6 Ivy LSP Tool Paper, AMC3 WP2 deliverables)
+
+---
+
+## 1. Context
+
+The PANTHER/ivy-lsp/panther-ivy-plugin stack implements an "endpoint-mirror-as-workspace" model for NCT (Network-Centric Compositional Testing). In this model, each master test file (e.g., `quic_client_test.ivy`) defines a complete workspace partition via its transitive include closure. The ivy-lsp server indexes this workspace, and the panther-ivy-plugin exposes it to Claude Code via MCP tools, hooks, skills, and agents.
+
+Before AMC3 WP2's 6-month POC sprint (Feb-Aug 2026), this document validates whether:
+1. The workspace model is conceptually sound and faithfully implemented
+2. The current implementation is competitive with state-of-the-art formal language tooling
+3. The gaps can be addressed within the POC timeline
+
+This feeds into P6 (Ivy LSP Tool Paper, TACAS/FSE 2027) and P3 (Agent-Driven Evidence, ICSE 2027 SEIP).
+
+---
+
+## 2. Validation Assessment
+
+### 2.1 Conceptual Validation
+
+**Verdict: Sound, with two documented caveats.**
+
+The model treats each test entry point as defining a complete workspace partition. This mirrors what `ivyc` sees when compiling that test — the compiler resolves includes from a flat directory and builds only the reachable graph.
+
+**Evidence of correctness**:
+- `_compute_test_scopes()` (`workspace_indexer.py:1324`) walks files with exports, computes transitive closure via `IncludeGraph.get_transitive_includes()`, and registers a `TestScope` with `include_closure` (FrozenSet), `exported_actions`, `imported_actions`, and `tester_role`
+- Role detection in `detect_test_role()` (`test_scope.py:75`) implements Ivy's role inversion by checking for `server_behavior`/`client_behavior` basename patterns in the include closure
+- The `test_file` parameter in coverage tools filters requirements to `scope.include_closure`, matching exactly the files PANTHER copies into the Docker staging directory
+
+**Caveat 1 — Basename collision semantics**: The flat symlink staging (`create_staging_directory()`, `include_resolver.py:223`) mirrors `ivyc`'s CWD-relative resolution. When two test scopes need different files sharing a basename, partitioned staging via graph coloring (`build_partitioned_staging()`) handles this. The greedy graph coloring is correct (produces optimal partitions when the conflict graph is a tree). Complexity is O(T x B x V) where T=test scopes, B=colliding basenames, V=variants per basename. For the QUIC workspace (~200 files, ~30 collisions, ~20 test scopes), this is negligible.
+
+**Caveat 2 — No cross-scope invariant checking**: Each test scope is treated independently. No mechanism verifies that shared files (e.g., `quic_connection.ivy` included by both client and server tests) maintain consistent assume-guarantee contracts across scopes. Theoretically safe by Ivy's compositionality guarantee, but not surfaced as a verifiable property.
+
+### 2.2 Layer-by-Layer Assessment
+
+#### Layer 1: Workspace Detection (`workspace_detection.py`, 321 lines) — Adequate
+
+**Implementation**: 6-strategy priority chain: explicit > hint > walk-up `.ivyworkspace` marker > walk-down marker > PANTHER heuristic > git worktree > fallback. The v2 `.ivyworkspace` schema supports `include_paths`, `exclude_paths`, `scope_detection`, `standard_library`, `project_type`.
+
+**Edge cases**:
+- Multiple `.ivyworkspace` in walk-down: returns FIRST found at any depth, not closest
+- `max_depth=10` in walk-up prevents infinite loops but could miss very deep markers
+- PANTHER heuristic false-positive: any dir with `protocol-testing/` + `panther_ivy.py`
+
+**Gap**: No multi-root workspace support (LSP 3.6 `workspace/didChangeWorkspaceFolders`).
+
+#### Layer 2: Include Resolution (`include_resolver.py`, 552 lines) — Novel, Strong
+
+**Implementation**: 4-step resolution chain (same dir > staging > workspace root > stdlib). Staging creates flat symlinks to all `.ivy` files, with first-sorted-path-wins collision handling. Partitioned staging via graph coloring for multi-test isolation.
+
+**Critical finding — ivyc divergence**: ivyc uses `open(name + '.ivy')` in CWD (2-step: CWD then stdlib). The LSP uses 4-step with staging as bridge. Step 3 (workspace root) is extra and could resolve files ivyc wouldn't find.
+
+**Edge cases**:
+- ~30 basename collisions in QUIC (e.g., `byte_stream.ivy` 3x, `file.ivy` 3x)
+- Dynamic file additions after staging creation miss new files until re-index
+- Symlink permissions on restricted systems
+
+**Gap**: Collisions logged at WARNING level but not surfaced as LSP diagnostics.
+
+#### Layer 3: Two-Phase Indexing (`workspace_indexer.py`, ~1400 lines) — Good Tradeoff
+
+**Implementation**: Phase 1 = fast lexer scan via regex/PLY (1-3s for 202 QUIC files, immediate LSP readiness). Phase 2 = background full parse from test entry points (files with exports, ~40 in QUIC, 10-30s). Thread-safe symbol swapping under `_table_lock` with atomic reference swap for concurrent reads.
+
+**Edge cases**:
+- Phase 2 interruption gracefully degrades to Phase 1 quality
+- Phase 2 removes Phase 1 requirements before adding full ones — mid-failure leaves gaps (caught by error handler)
+- `_source_cache` thread safety relies on Python GIL (safe but implicit)
+
+**Gap**: No incremental per-declaration re-indexing. Full re-index per file change.
+
+#### Layer 4: Test Scope Model (`test_scope.py`, 328 lines) — Novel, Strong
+
+**Implementation**: `TestScope` frozen dataclass with `include_closure` (FrozenSet), `exported_actions`, `imported_actions`, `tester_role`. `ScopedRequirementModel` extends `RequirementGraph` with per-test caching and proper invalidation. NCT classification: `_generating` -> TESTER_ONLY, `after/around` mixin -> GUARANTEE, `ensure/assert` -> GUARANTEE, else ASSUMPTION.
+
+**Quantitative**: ~40 test files, each closure 15-40 files. O(T x C) ~ 1000 graph lookups — fast.
+
+**Edge cases**:
+- Phantom test scope: shared behavior files with `export` create their own scope
+- Role detection heuristic fails for protocols not using `server_behavior`/`client_behavior` naming
+- `_generating` detection is string match in `formula_text` — reliable for Ivy convention but fragile if text unavailable
+
+**Gap**: No cross-scope invariant checking.
+
+#### Layer 5: Semantic Model (`analysis_pipeline.py` ~1000 lines, `model.py` 296 lines) — Adequate
+
+**Implementation**: T1 (<50ms, syntactic, RFC annotation parsing), T2 (<200ms, AST-enriched), T3 (background compiler). Thread-safe `SemanticModel` with RLock, tier-aware updates (higher overwrites lower). Generation tracking for stale T3 result rejection.
+
+**Gap**: No per-position semantic data (Lean 4 InfoTree equivalent).
+
+#### Layer 6: MCP Tools (`tools/`, 6 modules, ~130KB) — Novel, Strong
+
+**Implementation**: 15 consolidated tools with mode-based dispatch. `test_file` scoping correctly implements endpoint-mirror: `abs_test = ctx.validate_path(test_file)` -> `scope = graph.get_test_scope(abs_test)` -> filter to `scope.include_closure`. Path traversal prevention. Lazy model construction with async lock and 30s cooldown.
+
+**Edge cases**:
+- MCP standalone vs LSP mode model divergence (different code paths)
+- If `test_file` not yet indexed, fallback filters to just the test file itself, losing scope
+
+**Gap**: No CC evidence export format.
+
+#### Layer 7: Plugin Integration (`panther-ivy-plugin`) — Novel Architecture
+
+**Implementation**: 10 hook points, 15 observability scripts, `block-direct-ivy.sh` PreToolUse enforcement, `lint-before-verify.sh` PostToolUse auto-lint. `/nct-validate` with 55 checks across 7 phases. 4 agents (spec-analyst, methodology-guide, model-reviewer, traceability-agent), 11 skills, 9 commands.
+
+**Edge cases**:
+- Hook timeout (2-10s) — large logs cause silent timeout
+- `${CLAUDE_PLUGIN_ROOT}` must be correctly set by Claude Code
+
+**Gap**: No iterative verification skill, no LLM diff-checker.
+
+### 2.3 Alternative Approaches Analysis
+
+#### Workspace Scoping
+
+| Approach | Verdict | Reasoning |
+|----------|---------|-----------|
+| **Endpoint-mirror (current)** | **Keep** | NCT-aligned, matches PANTHER runtime, enables per-test coverage |
+| Module-based (Lean 4 style) | Incompatible | Ivy `include` is textual inclusion (like C `#include`), not module import — would require language changes |
+| Project-wide | Loses NCT alignment | Can't answer "which tests cover this requirement?" Cross-protocol pollution |
+| On-demand/lazy (Coq Fleche) | Incompatible with agent workflow | Agent needs workspace-wide views (coverage matrices); lazy indexing would materialize views per query |
+
+#### Include Resolution
+
+| Approach | Verdict | Reasoning |
+|----------|---------|-----------|
+| **Flat symlink staging (current)** | **Keep** | Faithful to ivyc, manageable complexity |
+| FUSE/overlay FS | Reject | macOS FUSE deprecated, Linux needs container privileges |
+| Rewrite-based | Reject | Changes file semantics, breaks ivyc compilation |
+| Compiler-integrated | Reject (hybrid possible) | ivyc global state, subprocess per include too slow. Use T3 to validate T2 resolution as hybrid. |
+
+#### Indexing Strategy
+
+| Approach | Verdict | Reasoning |
+|----------|---------|-----------|
+| **Two-phase lexer+parser (current)** | **Keep** | Best latency/correctness tradeoff for agent workflow |
+| Single-phase full parse | Reject | 30-60s startup blocks agent |
+| Incremental per-declaration | Future enhancement | Requires tree-sitter or custom parser — major effort |
+| Demand-driven | Reject | First coverage query triggers full parse anyway |
+
+#### MCP Tool Design
+
+| Approach | Verdict | Reasoning |
+|----------|---------|-----------|
+| **Mode-based consolidation (15 tools)** | **Keep** | Sweet spot of discoverability vs context efficiency (~1500 tokens) |
+| One-tool-per-operation (30+) | Reject | ~3000 tokens overhead, agent may choose wrong tool |
+| GraphQL-style single query | Reject | Shifts complexity to query construction, opaque errors |
+
+#### Plugin Architecture
+
+| Approach | Verdict | Reasoning |
+|----------|---------|-----------|
+| **Full plugin (skills + agents + hooks + commands)** | **Keep** | Essential enforcement and guidance for agent workflow |
+| Pure-MCP (tools only) | Loses enforcement | No hooks, no agents, no skills, no observability |
+| IDE extension (VS Code) | Complementary | No agent enforcement, no MCP access — targets humans, not AI |
+
+### 2.4 Threats to Validity
+
+| # | Threat | Prob | Severity | Mitigation In Place | Mitigation Needed |
+|---|--------|------|----------|---------------------|-------------------|
+| T1 | Basename collision -> wrong include resolution | MED | HIGH | Collision map, partitioned staging with graph coloring | Validate staging vs ivyc per test file (F5) |
+| T2 | Phase 1 regex misses includes | LOW | MED | Regex covers all standard Ivy; Phase 2 validates | None |
+| T3 | NCT classification incorrectness | MED | HIGH | Tested in `test_nct_classification.py`; `_generating` is reliable Ivy convention | Cross-validate against manual annotation |
+| T4 | MCP/LSP semantic model divergence | MED | MED | `build_semantic_model` shared code | Add test comparing both models |
+| T5 | Role detection heuristic brittleness | LOW (QUIC), HIGH (new protocols) | MED | Returns "unknown" when no heuristic matches | Explicit role annotation support |
+| T6 | Single-protocol evaluation | HIGH | MED | QUIC only | Demonstrate on CoAP by P6 submission |
+| T7 | Ground truth staleness | MED | MED | nct-validate checks 55 items | Automated ground truth from ivyc (I4) |
+| T8 | Std lib version mismatch | MED | MED | LSP selects highest version; ivyc selects lowest >= language version — different! | Fix LSP to match ivyc selection logic |
+| T9 | Agent context window saturation | HIGH | MED | Skills on demand; CLAUDE.md single page; mode consolidation | Token budget tracking |
+| T10 | Observability event-loss | LOW | LOW | `atexit` handlers | Event-loss detection (D5) |
+
+### 2.5 Related Work Comparison
+
+| System | Language | Scoping | Incremental | MCP/Agent | RFC Traceability | CC Evidence |
+|--------|----------|---------|-------------|-----------|------------------|-------------|
+| **ivy-lsp** | Ivy 1.7 | Endpoint-mirror | Per-file | 15 MCP + 4 agents | Bracket tags + manifests | Planned |
+| Lean 4 LSP | Lean 4 | Module | Per-declaration | No | N/A | No |
+| Coq Fleche | Coq | Document | Per-sentence | No | N/A | No |
+| DafnyPro | Dafny | Function | No | No | N/A | No |
+| lean-lsp-mcp | Lean 4 | Module | Reuses Lean | MCP wrapper (5 tools) | N/A | No |
+| SpecGen | Multiple | N/A | N/A | LLM loop | N/A | No |
+
+**Key differentiators**:
+- **vs Lean 4 LSP**: Finer granularity (per-declaration vs per-file) but no MCP, hooks, agent coordination, or RFC traceability. Per-declaration snapshots are gold standard for incrementality.
+- **vs Coq Fleche**: Viewport-following incompatible with MCP-first agent workflow. Per-sentence caching could inspire per-action caching.
+- **vs DafnyPro**: 86% correct proofs with Claude 3.5. Evaluation methodology (iterations-to-fix, per-complexity success rates) should inform P6. Fully automated loop vs our "guided convergence."
+- **vs lean-lsp-mcp**: Same MCP-wrapped-LSP pattern but 5 thin wrappers vs 15 deep-integrated tools. No traceability, quality gates, or visualization.
+- **vs SpecGen**: Mutation-based repair (syntactic) vs counterexample-guided repair (semantic). No traceability.
+
+---
+
+## 3. Improvement Roadmap
+
+### Phase 1: Foundation (Months 1-2) — LSP Core + LLM Safety
+
+#### F1: Incremental Per-File Re-Indexing
+
+**Problem**: `_remove_file_symbols()` rebuilds entire SymbolTable by copying all symbols except target — O(n) for 10,000+ symbols. `_compute_test_scopes()` clears all 200+ cache entries on every single-file reindex.
+
+**Changes**:
+1. `symbols.py` — Add `SymbolTable.remove_file(filepath) -> int` using in-place `_by_file.pop()` + prune `_by_name`/`_all`. O(k) vs O(n).
+2. `workspace_indexer.py:1091-1099` — Replace body with `self._symbol_table.remove_file(filepath)`.
+3. `workspace_indexer.py:1324` — `_compute_test_scopes(dirty_files=None)`. When provided, only invalidate cache entries whose `include_closure` intersects `dirty_files`.
+4. Wire: `reindex_file()` -> `_compute_test_scopes(dirty_files={abs_path})`.
+
+**Example**: Editing `quic_connection.ivy` — before: rebuild 10,000+ symbols, clear 200+ caches. After: remove ~50 symbols, clear ~12 affected caches.
+
+**Effort**: 2-3 weeks. **Enables**: D3, D4. **Impact**: P6 + P3.
+
+#### F2: Basename Collision Diagnostics
+
+**Changes**:
+1. `diagnostics.py` — New `_emit_collision_diagnostics()` emitting Warning on ambiguous `include` statements.
+2. `analysis.py` — Add `collisions` field to `ivy_include_graph` response.
+3. `include_resolver.py` — Add `get_collision_report() -> dict`.
+
+**Effort**: 1 week. **Impact**: P6.
+
+#### F3: LLM Diff-Checker Hook
+
+**Changes**:
+1. `hooks.json` — New PreToolUse hook for `Write|Edit` running `check-base-spec-guard.sh`.
+2. `.ivyworkspace` — `frozen_files: ["quic_stack/quic_types.ivy", "tls_stack/*.ivy"]`.
+3. New `check-base-spec-guard.sh` (~40 lines) — Parse TOOL_USE_INPUT, check against frozen list.
+
+**Minimal**: Glob matching. **Full**: `/nct-freeze`/`/nct-unfreeze` + auto-freeze.
+
+**Effort**: 2 weeks. **Impact**: P3 (gatekeeper).
+
+#### F4: Iterative Verification Skill
+
+**Changes**: New `skills/iterative-verification/SKILL.md` — CEGAR loop:
+1. `ivy_lint` (max 3 syntax retries)
+2. `ivy_verify(isolate=X)` — if counterexample, go to 3
+3. Diagnose via `counterexample-guide`
+4. Apply single fix
+5. Re-lint, re-verify (back to 1)
+6. Termination: pass OR iterations > 5
+7. Output: structured log per iteration
+
+**Example**: rfc9000:4.1 in `quic_server_test_stream.ivy` — lint (pass) -> verify (counterexample: `stream_state=idle`) -> fix (`require stream_state = open`) -> re-verify (pass). 2 iterations.
+
+**Effort**: 2 weeks. **Impact**: P3 (core loop).
+
+#### F5: Conformance Tests Against ivyc
+
+**Changes**: New `tests/conformance/` — compare LSP's `TestScope.include_closure` against `ivyc` actual resolution. `@pytest.mark.requires_ivy` skip when ivyc unavailable.
+
+**Effort**: 1 week. **Impact**: P6 (threat T1 mitigation).
+
+### Phase 2: Depth & Trust (Months 3-4) — CC Evidence + Verification Loop
+
+#### D1: CC Evidence Export
+
+**New MCP tool**: `ivy_cc_evidence(mode="adv_fsp"|"ate_fun"|"ava_van"|"ate_cov"|"full")`.
+
+| CC Family | Sub-Component | ivy-lsp Artifact |
+|-----------|---------------|------------------|
+| ADV_FSP.1-2 | Basic/security-enforcing spec | Exported action signatures + `require` guards |
+| ADV_FSP.3-4 | Complete with state model | State var read/write edges |
+| ADV_FSP.5-6 | Semi-formal/formal with correspondence | Ivy source + bracket tags + Z3 proofs |
+| ATE_FUN.1-2 | Functional/ordered testing | Per-isolate verdicts + 14-layer dependency graph |
+| AVA_VAN.1-5 | Vulnerability analysis (levels) | NACT error injection/mutation results |
+| ATE_COV.1-3 | Coverage (levels) | Requirement coverage per test scope |
+
+**Effort**: 3-4 weeks. **Impact**: P3 (flagship), WP2 D2.3.
+
+#### D2: Verification Failure Repair Hints
+
+**Changes**: `verification.py` — Add `error_category` and `repair_hints` to `ivy_verify` response:
+- `safety_violation` -> suggest `require {var} = {expected_value}`
+- `type_error` -> suggest type correction
+- `timeout` -> suggest `attribute {isolate}.timeout = 60`
+
+**Effort**: 3 weeks. **Impact**: P3 + P6.
+
+#### D3: Snapshot-Based Incremental Model Updates
+
+**Changes**: `requirement_graph.py` — `update_file_requirements()` for incremental re-wire. `workspace_indexer.py` — use incremental update in `reindex_file()`. Content hash tracking for skip-if-unchanged.
+
+**Benchmark**: Full wire ~100ms -> incremental ~5ms per file.
+
+**Effort**: 4 weeks. **Requires**: F1. **Impact**: P6.
+
+#### D4: Multi-Root Workspace Support
+
+**Changes**: `workspace_indexer.py` — `add_workspace_folder()`/`remove_workspace_folder()`. `server.py` — handle `workspace/didChangeWorkspaceFolders`. `.ivyworkspace` — `roots: [...]`.
+
+**Effort**: 3 weeks. **Impact**: P6.
+
+#### D5: Observability Event-Loss Detection
+
+**Changes**: SessionStart initializes monotonic counter. Each hook increments and logs sequence number. Stop hook compares vs expected, reports gaps.
+
+**Effort**: 1 week. **Impact**: P3.
+
+### Phase 3: Integration & Demo (Months 5-6) — Polish
+
+#### I1: LSIF Export
+
+New `ivy_lsp/lsif/exporter.py` (LSIF 0.4). MCP tool `ivy_lsif_export()`. CLI `--lsif-dump`.
+
+**Effort**: 3 weeks. **Impact**: P6 (artifact).
+
+#### I2: End-to-End Demo
+
+Scripted: lint -> verify (counterexample) -> fix -> re-verify (pass) -> coverage -> quality gate -> CC evidence. New `/nct-demo` command.
+
+**Effort**: 2 weeks. **Impact**: P3 + WP2.
+
+#### I3: Paper Evaluation Infrastructure
+
+New `evaluation/` with latency/accuracy/convergence benchmarks. See RQ1-RQ4 in Section 4.
+
+**Effort**: 3 weeks. **Impact**: P6 (evaluation section).
+
+#### I4: Automated Ground Truth from ivyc
+
+Script that captures ivyc include resolution per test entry point, generates `quic-workspace.yaml`. CI integration.
+
+**Effort**: 1 week. **Impact**: P6 + nct-validate.
+
+---
+
+## 4. Academic Positioning
+
+### 4.1 P6 Paper Evaluation Methodology
+
+**RQ1: Endpoint-mirror scoping accuracy vs project-wide**
+- Compare `ivy_coverage(mode="stats")` globally vs per `test_file`
+- Metrics: false positive rate, phantom coverage inflation
+- Expected: Project-wide inflates by 10-20% due to cross-scope tag bleeding
+- Ground truth: Manual verification of 20 random requirements
+
+**RQ2: LSP response latency across workspace sizes**
+- Synthetic workspaces: 10, 50, 100, 200, 500 files
+- Thresholds: Interactive <100ms p95, analysis <500ms p95, index <5s for 200 files
+- Report p50/p95/p99 for each tool
+
+**RQ3: Agent verification loop effectiveness (F4)**
+- 20 QUIC MUST requirements not yet formalized
+- Metrics: iterations-to-fix, success rate, time-to-fix, manual intervention rate
+- Expected: lint first-pass 85-90%, verify first-pass 40-60%, mean iterations 2-4, 75-85% within 5
+- Comparison: DafnyPro's 2.3 mean iterations (POPL 2026)
+
+**RQ4: Requirement extraction accuracy**
+- Compare `ivy_extract_requirements` vs manual `rfc9000_requirements.yaml` (90 reqs)
+- Metrics: precision (60-70%), recall (70-80%), F1, level accuracy (90%+)
+
+### 4.2 Novelty Claims
+
+1. **Endpoint-mirror workspace partitioning** — No prior art for test-entry-point-based workspace scoping in formal LSPs. Closest: contract-based hardware verification but not LSP-integrated.
+   - *Objection*: "QUIC-specific." *Response*: 14 layers map to general protocol engineering concepts.
+
+2. **Flat-symlink staging with graph-coloring partition isolation** — Novel for languages with CWD-relative includes.
+   - *Objection*: "Why not fix the language?" *Response*: Ivy is maintained by Microsoft Research; we build on top.
+
+3. **Three-tier progressive analysis pipeline** — T1<50ms, T2<200ms, T3 background.
+   - *Objection*: "Lean 4 does this better." *Response*: Per-file is appropriate for Ivy's smaller workspaces.
+
+4. **MCP-wrapped formal verification with RFC traceability** — 15 tools with bracket tags, coverage matrices, quality gates.
+   - *Objection*: "lean-lsp-mcp also wraps LSP." *Response*: 5 thin wrappers vs 15 deep-integrated tools.
+
+5. **Agent-as-a-Guide for CC evidence** — No published work automates the full CC pipeline from formal specs.
+   - *Objection*: "Engineering, not research." *Response*: Novel architectural patterns for safety-critical applications.
+
+### 4.3 WP2 Deliverable Mapping
+
+| Deliverable | What ivy-lsp Provides | Roadmap Items |
+|-------------|----------------------|---------------|
+| D2.1: Agent Architecture | "Agent-as-a-Guide" spec | F3, F4 |
+| D2.2: Tool Integration | MCP API, hooks, observability | F2, D5 |
+| D2.3: Evidence Generation | CC evidence (ADV_FSP + ATE_FUN + AVA_VAN + ATE_COV) | D1 |
+| D2.4: Evaluation | Benchmarks (RQ1-RQ4), iteration metrics | I2, I3 |
+
+### 4.4 CC Certification Detailed Mapping
+
+**ADV_FSP evidence format** (per exported action):
+```
+TSF Interface: quic_connection.open
+  Security Function: Connection establishment
+  Guard: require conn_state = closed  [rfc9000:4.1]
+  Effect: ensure conn_state = open  [rfc9000:4.1]
+  State Modified: conn_state, conn_seen
+  Verification: PASS (Z3, 2.3s, no counterexample)
+```
+
+**ATE_FUN evidence format** (per verified isolate):
+```
+Test Case: quic_server_test_stream/stream_send_isolate
+  SFR Traced: rfc9000:4.1, rfc9000:8.1
+  Verdict: PASS
+  Z3 Time: 2.3s
+  Dependencies: quic_types, quic_frame, quic_packet
+```
+
+**ATE_COV evidence format** (per test scope):
+```
+Protocol: QUIC (RFC 9000)
+  Total MUST: 52, Covered: 47 (90.4%)
+  Uncovered: [rfc9000:17.2.3, rfc9000:17.2.5, rfc9000:19.5, rfc9000:21.1, rfc9000:21.2]
+  Delta: +3 newly covered since last assessment
+```
+
+---
+
+## 5. Critical Files
+
+| File | Purpose | Roadmap Items |
+|------|---------|---------------|
+| `ivy_lsp/indexer/workspace_indexer.py` | Central indexer, test scope computation | F1, D3, D4 |
+| `ivy_lsp/indexer/include_resolver.py` | Include resolution, staging, collisions | F2, F5, T8 |
+| `ivy_lsp/analysis/test_scope.py` | NCT test scope model | Core novelty |
+| `ivy_lsp/workspace_detection.py` | Workspace auto-detection | D4 |
+| `ivy_lsp/semantic/analysis_pipeline.py` | 3-tier progressive analysis | D3 |
+| `ivy_lsp/tools/traceability.py` | MCP coverage/requirements tools | D1, I4 |
+| `ivy_lsp/tools/verification.py` | ivy_verify, error parsing | D2, F4 |
+| `panther-ivy-plugin/hooks/hooks.json` | Hook definitions | F3, D5 |
+| `panther-ivy-plugin/CLAUDE.md` | Operating guide | All |
+| `panther_ivy/ivy_command_mixin.py` | PANTHER workspace init | F5 validation |
+| `.ivyworkspace` | Workspace config (v2) | F3, D4 |

--- a/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
+++ b/docs/superpowers/specs/2026-03-18-nct-workspace-validation-design.md
@@ -56,12 +56,15 @@ The model treats each test entry point as defining a complete workspace partitio
 
 **Critical finding — ivyc divergence**: ivyc uses `open(name + '.ivy')` in CWD (2-step: CWD then stdlib). The LSP uses 4-step with staging as bridge. Step 3 (workspace root) is extra and could resolve files ivyc wouldn't find.
 
-**Edge cases**:
-- ~30 basename collisions in QUIC (e.g., `byte_stream.ivy` 3x, `file.ivy` 3x)
-- Dynamic file additions after staging creation miss new files until re-index
-- Symlink permissions on restricted systems
+**Known bug — Errno 17**: `build_partitioned_staging()` at line 446 calls `os.symlink()` without `os.path.lexists()` guard, producing `[Errno 17] File exists` errors. The main `create_staging_directory()` has this guard (line 265) but the partitioned variant does not.
 
-**Gap**: Collisions logged at WARNING level but not surfaced as LSP diagnostics.
+**Edge cases**:
+- ~50 basename collisions between APT and standard models (e.g., `ivy_quic_client.ivy` in both `quic/` and `apt/quic/`) — `.ivyworkspace` v2 `include_paths: ["protocol-testing"]` includes both
+- ~30 additional collisions within QUIC (e.g., `byte_stream.ivy` 3x, `file.ivy` 3x)
+- Dynamic file additions after staging creation miss new files until re-index
+- No VFS abstraction — raw symlink management with no atomic refresh, reference counting, or lifecycle encapsulation
+
+**Gaps**: (a) Collisions logged but not surfaced as LSP diagnostics. (b) Errno 17 bug in partitioned staging. (c) No VFS abstraction layer. (d) APT/standard workspace separation needed (v3 schema).
 
 #### Layer 3: Two-Phase Indexing (`workspace_indexer.py`, ~1400 lines) — Good Tradeoff
 
@@ -95,13 +98,14 @@ The model treats each test entry point as defining a complete workspace partitio
 
 #### Layer 6: MCP Tools (`tools/`, 6 modules, ~130KB) — Novel, Strong
 
-**Implementation**: 15 consolidated tools with mode-based dispatch. `test_file` scoping correctly implements endpoint-mirror: `abs_test = ctx.validate_path(test_file)` -> `scope = graph.get_test_scope(abs_test)` -> filter to `scope.include_closure`. Path traversal prevention. Lazy model construction with async lock and 30s cooldown.
+**Implementation**: 34 registered `@mcp.tool()` functions — **15 primary tools + 19 legacy aliases** (per indexing-improvements audit). `test_file` scoping correctly implements endpoint-mirror: `abs_test = ctx.validate_path(test_file)` -> `scope = graph.get_test_scope(abs_test)` -> filter to `scope.include_closure`. Path traversal prevention. Lazy model construction with async lock and 30s cooldown.
 
 **Edge cases**:
 - MCP standalone vs LSP mode model divergence (different code paths)
 - If `test_file` not yet indexed, fallback filters to just the test file itself, losing scope
+- `ivy_quality(mode="suggestions")` `_resolve_scope` does not derive testFile from filePath (P8 bug)
 
-**Gap**: No CC evidence export format.
+**Gaps**: (a) 19 legacy aliases bloat prompt ~56% (34->15 after removal, per arXiv:2510.14537 tool taxonomy research). (b) No CC evidence export format. (c) No taxonomy-based categorization for 6-category LLM tool selection guidance.
 
 #### Layer 7: Plugin Integration (`panther-ivy-plugin`) — Novel Architecture
 
@@ -194,6 +198,45 @@ The model treats each test entry point as defining a complete workspace partitio
 ---
 
 ## 3. Improvement Roadmap
+
+### Phase 0: Immediate — Remove Legacy Debt & Fix Bugs
+
+#### F0a: Remove 19 Legacy MCP Tool Aliases (34 -> 15 tools)
+
+**Problem**: 19 backward-compatibility `@mcp.tool()` aliases duplicate the 15 primary consolidated tools. They bloat the MCP prompt ~56% and confuse tool selection. Plugin docs already use consolidated names only.
+
+**Aliases to delete** (4 files):
+
+| Module | Aliases | Lines |
+|--------|---------|-------|
+| `traceability.py` | `ivy_requirement_coverage`, `ivy_coverage_gaps`, `ivy_traceability_matrix`, `ivy_query_symbol`, `ivy_impact_analysis`, `ivy_cross_references`, `ivy_generate_manifest` | 1241-1294 |
+| `visualization.py` | `ivy_action_dependency_graph`, `ivy_state_machine_view`, `ivy_layered_overview`, `ivy_action_requirements` | 313-342 |
+| `patterns.py` | `ivy_pattern_analysis`, `ivy_scaffold_check` | 282-297 |
+| `quality.py` | `ivy_smart_suggestions`, `ivy_quality_gate` | 368-383 |
+
+**Verification**: `pytest tests/`, `/nct-validate` (update tool count ground truth), `/nct-health`.
+
+**Effort**: 1 day.
+
+#### F0b: Fix Errno 17 Symlink Bug
+
+`build_partitioned_staging()` at `include_resolver.py:446` — add `if os.path.lexists(link_path): os.unlink(link_path)` before `os.symlink()`. Add startup cleanup for stale `ivy-lsp-stage-*` dirs.
+
+**Effort**: 1 hour.
+
+#### F0c: Fix ivy_quality Context Scoping (P8)
+
+`_resolve_scope` in `visualization.py` — when testFile is None and filePath is provided, derive scope via `graph.get_tests_for_file(file_path)`.
+
+**Effort**: 2 hours.
+
+#### F0d: Demand-Driven Deep Parse for Shared Modules (P4)
+
+Add `deep_parse_on_demand(filepath)` to `WorkspaceIndexer`. Wire into hover, goto-def, and document-symbols handlers. Shared libraries get AST-quality symbols on first interaction.
+
+**Effort**: 1-2 days.
+
+---
 
 ### Phase 1: Foundation (Months 1-2) — LSP Core + LLM Safety
 
@@ -412,12 +455,18 @@ Protocol: QUIC (RFC 9000)
 
 | File | Purpose | Roadmap Items |
 |------|---------|---------------|
-| `ivy_lsp/indexer/workspace_indexer.py` | Central indexer, test scope computation | F1, D3, D4 |
-| `ivy_lsp/indexer/include_resolver.py` | Include resolution, staging, collisions | F2, F5, T8 |
+| `ivy_lsp/tools/traceability.py` | MCP coverage/requirements + 7 legacy aliases | **F0a**, D1, I4 |
+| `ivy_lsp/tools/visualization.py` | MCP visualization + 4 legacy aliases + `_resolve_scope` | **F0a**, **F0c** |
+| `ivy_lsp/tools/patterns.py` | MCP patterns + 2 legacy aliases | **F0a** |
+| `ivy_lsp/tools/quality.py` | MCP quality + 2 legacy aliases | **F0a** |
+| `ivy_lsp/indexer/include_resolver.py` | Include resolution, staging, Errno 17 bug | **F0b**, F2, F5, T8 |
+| `ivy_lsp/indexer/workspace_indexer.py` | Central indexer, deep_parse_on_demand | **F0d**, F1, D3, D4 |
+| `ivy_lsp/features/hover.py` | Hover — wire demand-driven deep parse | **F0d** |
+| `ivy_lsp/features/definition.py` | Goto-def — wire demand-driven deep parse | **F0d** |
+| `ivy_lsp/features/document_symbols.py` | Outline — wire demand-driven deep parse | **F0d** |
 | `ivy_lsp/analysis/test_scope.py` | NCT test scope model | Core novelty |
 | `ivy_lsp/workspace_detection.py` | Workspace auto-detection | D4 |
 | `ivy_lsp/semantic/analysis_pipeline.py` | 3-tier progressive analysis | D3 |
-| `ivy_lsp/tools/traceability.py` | MCP coverage/requirements tools | D1, I4 |
 | `ivy_lsp/tools/verification.py` | ivy_verify, error parsing | D2, F4 |
 | `panther-ivy-plugin/hooks/hooks.json` | Hook definitions | F3, D5 |
 | `panther-ivy-plugin/CLAUDE.md` | Operating guide | All |

--- a/docs/superpowers/specs/2026-03-19-lsp-mcp-crash-resilience-design.md
+++ b/docs/superpowers/specs/2026-03-19-lsp-mcp-crash-resilience-design.md
@@ -1,0 +1,262 @@
+# LSP/MCP Crash Resilience & Bug Fixes
+
+**Date**: 2026-03-19
+**Branch**: `refactor/ivy-lsp-cleanup` (worktree: `lsp-to-claude`)
+**Scope**: ivy-lsp submodule + panther-ivy-plugin submodule
+**Approach**: Prioritized hybrid — crash prevention first, then resilience, then correctness
+
+## Context
+
+Analysis of conversation log (`2026-03-19-105122-*.txt`) and Claude Code debug log (`c8fe62ac-*.txt`) revealed 7 problem categories affecting the Ivy LSP + MCP integration. The LSP server crashed with SIGTERM (exit code 143) during an `nct-validate` run, causing all 14+ MCP tools to become unavailable. A separate JSONDecodeError crash was also observed. Cross-validation of MCP tools vs LSP operations showed only 40% agreement.
+
+### Root Causes Identified
+
+| ID | Problem | Severity | Root Cause |
+|----|---------|----------|------------|
+| P1 | LSP crash exit code 143 | Critical | Stale PID cleanup in `start-ivy-server.sh` sends SIGTERM to running server |
+| P2 | Cascade: MCP tools "not found" after crash | Critical | No auto-reconnect; Claude Code deregisters tools when server dies |
+| P3 | JSONDecodeError kills stdio LSP | High | pygls message loop crashes on malformed JSON instead of rejecting |
+| P4 | 7-minute first-call latency | Medium | Lazy model build on first `ivy_coverage` call |
+| P5 | 7 functional failures (nct-validate) | Medium | Various bugs in hover, workspaceSymbol, xref graph, definition, patterns |
+| P6 | 40% cross-validation agreement | Medium | MCP tools and LSP operations return inconsistent results for same queries |
+| P7 | "server is running" but can't send | Medium | stdio transport blocked; no request queuing |
+
+### Evidence Timeline (from debug log)
+
+```
+09:32:18  MCP server connected (ivy-tools, version "ivy-lsp 1.26.0")
+09:33:45  LSP server instance started
+09:33:46  First MCP tool calls (ivy_capabilities, ivy_lint) — fast
+09:33:46  First ivy_coverage call begins
+09:40:42  First ivy_coverage completes — 6m 55s (lazy model build)
+09:44:08  Subsequent ivy_coverage calls — 3ms-28ms (cached)
+09:47:24  Last successful tool call (Bash PostToolUse hook)
+09:47:43  LSP server crashed: exit code 143 (SIGTERM)
+09:47:43  LSP server connection closed
+09:48:26  ALL MCP tools become "Tool not found" (39+ errors in rapid succession)
+```
+
+---
+
+## Phase 1: Crash Prevention
+
+Targeted fixes to prevent the two observed crash modes. Smallest scope, highest impact.
+
+### 1a. Fix PID cleanup race in `start-ivy-server.sh`
+
+**File**: `panther-ivy-plugin/.../scripts/start-ivy-server.sh` (lines 70-98)
+
+**Current behavior**: The script kills any running server with the same `${MODE}-${_WS_HASH}` prefix. When Claude Code spawns a subagent that triggers a new server launch for the same workspace, the stale cleanup kills the live server mid-operation.
+
+**Fix**: Add session scoping to PID prefix using parent PID or Claude session ID:
+
+```bash
+# Session-scoped PID prefix: avoids cross-session kills
+_SESSION_ID="${CLAUDE_SESSION_ID:-$PPID}"
+_PID_PREFIX="${MODE}-${_WS_HASH}-${_SESSION_ID}"
+```
+
+Only kill PIDs from the same parent session. The dead-PID cleanup (lines 91-98) stays unchanged and handles stale leftovers from any session.
+
+**Validation**: Launch two concurrent Claude sessions in the same workspace; verify neither kills the other's server.
+
+### 1b. Add SIGTERM/SIGINT signal handlers
+
+**File**: `ivy-lsp/ivy_lsp/__main__.py`
+
+**Current behavior**: No signal handlers. SIGTERM causes immediate process death — no log flush, no staging cleanup, no audit summary.
+
+**Fix**: Install signal handlers before starting either server mode:
+
+```python
+import signal
+
+def _graceful_shutdown(signum, frame):
+    log.info("Received signal %d, shutting down gracefully", signum)
+    raise SystemExit(128 + signum)
+
+signal.signal(signal.SIGTERM, _graceful_shutdown)
+signal.signal(signal.SIGINT, _graceful_shutdown)
+```
+
+This converts SIGTERM into `SystemExit`, which Python's `try/finally` and `atexit` handlers can catch. The existing `on_shutdown` handler in `server.py` and cleanup logic in `mcp_server.py` then execute normally.
+
+**Validation**: Send SIGTERM to running server; verify log file contains shutdown audit summary.
+
+### 1c. Graceful JSON-RPC error handling
+
+**File**: `ivy-lsp/ivy_lsp/__main__.py` (extend existing `_patch_pygls_converter`)
+
+**Current behavior**: `json.decoder.JSONDecodeError` in pygls message loop crashes the entire LSP server. The existing `_fixed_params_hook` handles missing `params` but not malformed JSON.
+
+**Fix**: Monkey-patch the pygls protocol's JSON deserialization entry point to catch `JSONDecodeError` and `ValidationError`. Log the malformed message and continue instead of crashing:
+
+```python
+def _patch_pygls_json_handler(server):
+    """Wrap pygls message deserialization to survive malformed JSON."""
+    protocol = server.protocol
+    _original_data_received = protocol.data_received
+
+    def _safe_data_received(data):
+        try:
+            _original_data_received(data)
+        except (json.JSONDecodeError, Exception) as e:
+            logger.error("Malformed JSON-RPC message (discarded): %s", e)
+            # Don't crash — continue processing next messages
+
+    protocol.data_received = _safe_data_received
+```
+
+**Validation**: Send malformed JSON to server stdin; verify server logs error and continues responding to subsequent valid requests.
+
+---
+
+## Phase 2: Resilience
+
+Architectural improvements so the system degrades gracefully instead of catastrophically.
+
+### 2a. Eager model pre-warming on MCP startup
+
+**File**: `ivy-lsp/ivy_lsp/mcp_server.py` (inside `start_mcp()`, after tool registration)
+
+**Current behavior**: Semantic model built lazily on first tool call (`_get_model()` at line 471). First `ivy_coverage` takes 6m 55s.
+
+**Fix**: Start model building immediately as a background asyncio task:
+
+```python
+# After register_all_tools(mcp, ctx):
+async def _prewarm():
+    try:
+        await _get_model()
+        logger.info("Semantic model pre-warmed successfully")
+    except Exception:
+        logger.warning("Model pre-warm failed; will retry on first tool call", exc_info=True)
+
+# Schedule pre-warming (runs after event loop starts)
+import asyncio
+asyncio.get_event_loop().create_task(_prewarm())
+```
+
+Add `model_status` field to `ivy_capabilities` response: `"building"` / `"ready"` / `"failed"`.
+
+**Validation**: Start MCP server; call `ivy_capabilities` immediately — should show `"model_status": "building"`. Wait, call again — should show `"ready"`.
+
+### 2b. Request queuing limitation (document only)
+
+**Problem**: "Cannot send request to LSP server: server is running" — the Claude Code LSP client doesn't queue requests when the stdio transport is busy.
+
+**Status**: This is a **Claude Code client-side limitation**, not fixable server-side. The server already uses `@self.thread()` for heavy operations.
+
+**Mitigation**: Document in plugin CLAUDE.md that LSP operations may fail with "server is running" when the server is processing a heavy request. Recommend retrying after a short delay. Consider adding a retry wrapper in the plugin's hooks if this is frequent.
+
+### 2c. Staging directory cleanup on SIGTERM
+
+**File**: `ivy-lsp/ivy_lsp/mcp_server.py` (inside `start_mcp()`)
+
+**Current behavior**: Staging directory (with flat symlinks) is not cleaned up on SIGTERM.
+
+**Fix**: Register atexit cleanup after staging directory creation:
+
+```python
+import atexit, shutil
+if staging_dir:
+    atexit.register(lambda sd=staging_dir: shutil.rmtree(sd, ignore_errors=True))
+```
+
+Phase 1's signal handler (1b) ensures atexit runs on SIGTERM.
+
+**Validation**: Start server, verify staging dir exists, send SIGTERM, verify staging dir is cleaned up.
+
+### 2d. Bidirectional model cache
+
+**File**: `ivy-lsp/ivy_lsp/mcp_server.py` (inside `_get_model()`, after successful build)
+
+**Current behavior**: LSP server writes semantic model cache to disk after bulk analysis. MCP server reads it. But MCP never writes its own builds to the cache.
+
+**Fix**: After MCP's own model build succeeds, write to the shared cache location:
+
+```python
+if semantic_model is not None:
+    write_model_cache(root, semantic_model, _req_graph)
+```
+
+This way, if MCP crashes and restarts, the next instance gets a warm cache instead of rebuilding for 7 minutes.
+
+**Validation**: Start MCP, wait for model build, kill server, restart — second startup should show "Loaded semantic model from shared cache" in logs.
+
+---
+
+## Phase 3: Functional Correctness
+
+Six independent bug fixes. Each requires reading the specific handler code to confirm exact root cause. Lower priority — edge cases, not core stability.
+
+### 3a. Hover file attribution
+
+**Files**: `ivy-lsp/ivy_lsp/features/hover.py`
+
+**Symptom**: Hover for `cid` says "Defined in: ping_types.ivy" but actual definition is `quic_types.ivy:30`.
+
+**Fix**: When multiple files define the same symbol, prefer the file in the current document's include closure over alphabetical first match.
+
+### 3b. workspaceSymbol cursor-to-query extraction
+
+**Files**: `ivy-lsp/ivy_lsp/features/workspace_symbol.py` (or equivalent)
+
+**Symptom**: workspaceSymbol at cursor returns 100 unrelated symbols from `apt_entities/` instead of results for the word under cursor.
+
+**Fix**: Verify whether the handler extracts the word at cursor position. If not, add word extraction from the active document.
+
+### 3c. MCP xref graph for module-scoped types
+
+**Files**: `ivy-lsp/ivy_lsp/semantic/model.py` or `semantic/cross_refs.py`
+
+**Symptom**: `ivy_query(mode=impact)` returns 0 edges for `quic_packet_type` while LSP `findReferences` returns 406 refs.
+
+**Fix**: Extend xref graph edge-building to include `object`/`module` declarations, not just `action`/`function`.
+
+### 3d. goToDefinition for inner enum classes
+
+**Files**: `ivy-lsp/ivy_lsp/features/definition.py`
+
+**Symptom**: goToDefinition at line 130 (inner enum body) returns nothing; line 129 (outer module) works.
+
+**Fix**: When no definition found at exact position, walk up to nearest enclosing `object`/`module` declaration.
+
+### 3e. Pattern name normalization
+
+**Files**: `ivy-lsp/ivy_lsp/tools/patterns.py`
+
+**Symptom**: `ivy_pattern_scaffold(pattern="monitor")` fails — requires exact plural "monitors".
+
+**Fix**: Add singular→plural normalization map: `{"monitor": "monitors", "variant": "variants", "shim": "shim", ...}`.
+
+### 3f. ivy_model_info for library files
+
+**Files**: `ivy-lsp/ivy_lsp/tools/verification.py`
+
+**Symptom**: `ivy_model_info(quic_types.ivy)` errors with "no isolate specified" for library modules.
+
+**Fix**: Detect no-isolate files and fall back to structural analysis or auto-detect the isolate from module structure.
+
+---
+
+## Out of Scope
+
+- Claude Code client-side LSP request queuing (P7 — framework limitation)
+- Claude Code MCP server auto-reconnect after crash (P2 — framework behavior)
+- Performance optimization of semantic model building beyond pre-warming
+- Changes to the nct-validate ground truth spec
+
+## Testing Strategy
+
+- **Phase 1**: Manual testing — send SIGTERM, send malformed JSON, launch concurrent sessions
+- **Phase 2**: Integration testing — verify model pre-warming via `ivy_capabilities`, verify cache round-trip
+- **Phase 3**: Unit tests per handler + re-run `/nct-validate` to confirm fixes
+
+## Phasing
+
+| Phase | Items | PRs | Risk |
+|-------|-------|-----|------|
+| 1 | 1a, 1b, 1c | 1 PR into ivy-lsp + 1 PR into panther-ivy-plugin | Low — targeted fixes |
+| 2 | 2a, 2b, 2c, 2d | 1 PR into ivy-lsp | Medium — touches startup path |
+| 3 | 3a–3f | 1 PR into ivy-lsp | Low — independent fixes |

--- a/docs/superpowers/specs/2026-03-19-lsp-mcp-crash-resilience-design.md
+++ b/docs/superpowers/specs/2026-03-19-lsp-mcp-crash-resilience-design.md
@@ -46,13 +46,20 @@ Targeted fixes to prevent the two observed crash modes. Smallest scope, highest 
 
 **File**: `panther-ivy-plugin/.../scripts/start-ivy-server.sh` (lines 70-98)
 
-**Current behavior**: The script kills any running server with the same `${MODE}-${_WS_HASH}` prefix. When Claude Code spawns a subagent that triggers a new server launch for the same workspace, the stale cleanup kills the live server mid-operation.
+**Current behavior**: The script kills any running server with the same `${MODE}-${_WS_HASH}` prefix. When a concurrent Claude session (or subagent) for the same workspace triggers a new server launch, the stale cleanup (line 86: `kill -TERM "$old_pid"`) kills the other session's live server mid-operation. The existing guard `[ "$old_pid" = "$$" ] && continue` (line 83) only prevents self-kill, not cross-session kill.
 
-**Fix**: Add session scoping to PID prefix using parent PID or Claude session ID:
+**Failure sequence**: Session A starts → launches LSP (PID 100). Session B starts (same workspace) → cleanup finds PID 100 under `lsp-<hash>` → kills it → Session A's LSP dies with exit code 143.
+
+**Fix**: Add session scoping to PID prefix using `$PPID` (parent process ID):
 
 ```bash
 # Session-scoped PID prefix: avoids cross-session kills
-_SESSION_ID="${CLAUDE_SESSION_ID:-$PPID}"
+# $PPID is the Claude Code process that launched this script.
+# NOTE: CLAUDE_SESSION_ID does not exist as an env var today;
+# $PPID is the actual mechanism. If Claude launches through
+# intermediate shells, $PPID may be unreliable — but this still
+# reduces the race window vs. the current approach.
+_SESSION_ID="${PPID}"
 _PID_PREFIX="${MODE}-${_WS_HASH}-${_SESSION_ID}"
 ```
 
@@ -81,30 +88,44 @@ signal.signal(signal.SIGINT, _graceful_shutdown)
 
 This converts SIGTERM into `SystemExit`, which Python's `try/finally` and `atexit` handlers can catch. The existing `on_shutdown` handler in `server.py` and cleanup logic in `mcp_server.py` then execute normally.
 
+**Risk — asyncio interaction**: For MCP mode (which runs under `mcp.run(transport="stdio")`, an asyncio event loop), raising `SystemExit` from a signal handler while inside an asyncio event loop may not allow `atexit` handlers to run if the loop is blocked. For the MCP path, use `loop.add_signal_handler()` instead of raw `signal.signal()`:
+
+```python
+# For MCP (asyncio) path:
+loop = asyncio.get_event_loop()
+loop.add_signal_handler(signal.SIGTERM, lambda: sys.exit(128 + signal.SIGTERM))
+```
+
 **Validation**: Send SIGTERM to running server; verify log file contains shutdown audit summary.
 
 ### 1c. Graceful JSON-RPC error handling
 
-**File**: `ivy-lsp/ivy_lsp/__main__.py` (extend existing `_patch_pygls_converter`)
+**File**: `ivy-lsp/ivy_lsp/pygls_patches.py` (add new patch alongside existing `_patch_pygls_cancelled_future` and `_patch_pygls_closed_pipe`)
 
-**Current behavior**: `json.decoder.JSONDecodeError` in pygls message loop crashes the entire LSP server. The existing `_fixed_params_hook` handles missing `params` but not malformed JSON.
+**Current behavior**: `json.decoder.JSONDecodeError` in pygls message loop crashes the entire LSP server. The existing `_fixed_params_hook` in `__main__.py` handles missing `params` (cattrs converter) but not malformed JSON at the transport layer.
 
-**Fix**: Monkey-patch the pygls protocol's JSON deserialization entry point to catch `JSONDecodeError` and `ValidationError`. Log the malformed message and continue instead of crashing:
+**Implementation note**: pygls 2.0.x does NOT expose `data_received` on `JsonRPCProtocol`. The JSON deserialization happens inside pygls internals before `_handle_request` / `_handle_notification` are called. The exact entry point must be identified by tracing the pygls source for the message-parsing layer (likely in the `JsonRPCProtocol._procedure_handler` or the transport's message framing). The existing `pygls_patches.py` already patches `_handle_response` and `set_writer` on `JsonRPCProtocol`, establishing the pattern.
+
+**Fix approach** (requires sub-investigation of pygls internals):
+
+1. Identify the pygls method that deserializes incoming JSON-RPC messages (the step before `_handle_request`)
+2. Add a new patch function in `pygls_patches.py` that wraps this method
+3. Catch `json.JSONDecodeError` and `cattrs.errors.ClassValidationError`, log at ERROR level, and return (skip the malformed message)
+4. Register the patch in `apply_patches()` alongside the existing patches
 
 ```python
-def _patch_pygls_json_handler(server):
-    """Wrap pygls message deserialization to survive malformed JSON."""
-    protocol = server.protocol
-    _original_data_received = protocol.data_received
+def _patch_pygls_json_safety() -> None:
+    """Wrap pygls message deserialization to survive malformed JSON.
 
-    def _safe_data_received(data):
-        try:
-            _original_data_received(data)
-        except (json.JSONDecodeError, Exception) as e:
-            logger.error("Malformed JSON-RPC message (discarded): %s", e)
-            # Don't crash — continue processing next messages
+    The exact method to patch depends on pygls 2.0.x internals.
+    Candidate: the method that calls json.loads() on incoming data,
+    typically in the transport layer or JsonRPCProtocol._procedure_handler.
+    """
+    from pygls.protocol.json_rpc import JsonRPCProtocol
 
-    protocol.data_received = _safe_data_received
+    # TODO: Identify exact method via pygls source inspection.
+    # Pattern: wrap with try/except json.JSONDecodeError, log, continue.
+    ...
 ```
 
 **Validation**: Send malformed JSON to server stdin; verify server logs error and continues responding to subsequent valid requests.
@@ -121,10 +142,11 @@ Architectural improvements so the system degrades gracefully instead of catastro
 
 **Current behavior**: Semantic model built lazily on first tool call (`_get_model()` at line 471). First `ivy_coverage` takes 6m 55s.
 
-**Fix**: Start model building immediately as a background asyncio task:
+**Fix**: Start model building as a background task. Since `mcp.run(transport="stdio")` starts the asyncio event loop, `asyncio.get_event_loop().create_task()` can't be called before `mcp.run()`. Instead, use FastMCP's lifecycle hooks or schedule the task inside the first tool call, or use a `startup` event:
 
 ```python
-# After register_all_tools(mcp, ctx):
+# Option A: Use FastMCP's lifespan/startup hook if available
+@mcp.on_event("startup")
 async def _prewarm():
     try:
         await _get_model()
@@ -132,10 +154,14 @@ async def _prewarm():
     except Exception:
         logger.warning("Model pre-warm failed; will retry on first tool call", exc_info=True)
 
-# Schedule pre-warming (runs after event loop starts)
-import asyncio
-asyncio.get_event_loop().create_task(_prewarm())
+# Option B: If FastMCP doesn't support lifecycle hooks,
+# add a lightweight wrapper around mcp.run():
+async def _run_with_prewarm():
+    asyncio.create_task(_prewarm())
+    await mcp._run_stdio()  # internal method — check FastMCP API
 ```
+
+The exact approach depends on FastMCP's lifecycle API — requires sub-investigation during implementation.
 
 Add `model_status` field to `ivy_capabilities` response: `"building"` / `"ready"` / `"failed"`.
 
@@ -173,11 +199,14 @@ Phase 1's signal handler (1b) ensures atexit runs on SIGTERM.
 
 **Current behavior**: LSP server writes semantic model cache to disk after bulk analysis. MCP server reads it. But MCP never writes its own builds to the cache.
 
-**Fix**: After MCP's own model build succeeds, write to the shared cache location:
+**Fix**: After MCP's own model build succeeds, write to the shared cache location. The `write_model_cache` signature requires 4 parameters including a freshness key (see `bulk_orchestrator.py:80` for reference):
 
 ```python
-if semantic_model is not None:
-    write_model_cache(root, semantic_model, _req_graph)
+from ivy_lsp.indexer.shared_cache import compute_freshness_key, write_model_cache
+
+ivy_files = _find_ivy_files(root)
+freshness = compute_freshness_key(root, ivy_files)
+write_model_cache(root, semantic_model, _req_graph, freshness)
 ```
 
 This way, if MCP crashes and restarts, the next instance gets a warm cache instead of rebuilding for 7 minutes.
@@ -188,7 +217,9 @@ This way, if MCP crashes and restarts, the next instance gets a warm cache inste
 
 ## Phase 3: Functional Correctness
 
-Six independent bug fixes. Each requires reading the specific handler code to confirm exact root cause. Lower priority — edge cases, not core stability.
+Six independent bug fixes. Lower priority — edge cases, not core stability.
+
+**Sub-investigation required**: Each fix below requires reading the specific handler code to confirm the exact root cause before implementation. The symptom descriptions are from nct-validate observations; the proposed fixes are hypotheses that may need adjustment once the actual code is inspected. Budget investigation time per item.
 
 ### 3a. Hover file attribution
 
@@ -198,19 +229,23 @@ Six independent bug fixes. Each requires reading the specific handler code to co
 
 **Fix**: When multiple files define the same symbol, prefer the file in the current document's include closure over alphabetical first match.
 
-### 3b. workspaceSymbol cursor-to-query extraction
+### 3b. workspaceSymbol query handling
 
-**Files**: `ivy-lsp/ivy_lsp/features/workspace_symbol.py` (or equivalent)
+**Files**: `ivy-lsp/ivy_lsp/features/workspace_symbols.py`
 
-**Symptom**: workspaceSymbol at cursor returns 100 unrelated symbols from `apt_entities/` instead of results for the word under cursor.
+**Symptom**: workspaceSymbol returns 100 unrelated symbols from `apt_entities/` instead of results for `cid`.
 
-**Fix**: Verify whether the handler extracts the word at cursor position. If not, add word extraction from the active document.
+**Note**: LSP `workspace/symbol` is a **query-based** request — the client sends a query string, not a cursor position. The word-at-cursor extraction must happen **client-side** (Claude Code LSP adapter). The server receives `params.query` and does substring matching.
 
-### 3c. MCP xref graph for module-scoped types
+**Fix**: Investigate whether the issue is:
+- **Client-side** (Claude Code sends empty/wrong query) — if so, this is out of scope for ivy-lsp
+- **Server-side** (handler ignores `params.query` or returns truncated/unsorted results) — if so, fix the query matching and result ordering to prioritize exact matches
+
+### 3c. Semantic model xref graph for module-scoped types
 
 **Files**: `ivy-lsp/ivy_lsp/semantic/model.py` or `semantic/cross_refs.py`
 
-**Symptom**: `ivy_query(mode=impact)` returns 0 edges for `quic_packet_type` while LSP `findReferences` returns 406 refs.
+**Symptom**: The semantic model's impact traversal returns 0 cross-reference edges for `quic_packet_type` while LSP `findReferences` (which uses the lexical index) returns 406 refs. Note: the `ivy_query` MCP tool has been removed — the underlying semantic model's impact/xref graph is what needs fixing, as it's used by `ivy_coverage` and visualization tools.
 
 **Fix**: Extend xref graph edge-building to include `object`/`module` declarations, not just `action`/`function`.
 
@@ -258,5 +293,5 @@ Six independent bug fixes. Each requires reading the specific handler code to co
 | Phase | Items | PRs | Risk |
 |-------|-------|-----|------|
 | 1 | 1a, 1b, 1c | 1 PR into ivy-lsp + 1 PR into panther-ivy-plugin | Low — targeted fixes |
-| 2 | 2a, 2b, 2c, 2d | 1 PR into ivy-lsp | Medium — touches startup path |
-| 3 | 3a–3f | 1 PR into ivy-lsp | Low — independent fixes |
+| 2 | 2a, 2b (docs only), 2c, 2d | 1 PR into ivy-lsp (2b is CLAUDE.md update only) | Medium — touches startup path |
+| 3 | 3a–3f (each needs sub-investigation) | 1 PR into ivy-lsp | Low — independent fixes |

--- a/docs/superpowers/specs/2026-03-20-lazy-bridge-mcp-architecture-design.md
+++ b/docs/superpowers/specs/2026-03-20-lazy-bridge-mcp-architecture-design.md
@@ -1,0 +1,225 @@
+# Lazy Bridge MCP Architecture
+
+**Date:** 2026-03-20
+**Status:** Approved
+**Branch:** `refactor/ivy-lsp-cleanup` (worktree: `lsp-to-claude`)
+
+## Problem
+
+The Ivy MCP server fails to start reliably in Claude Code sessions. The current `mcp-bridge` architecture creates a race condition:
+
+1. Claude Code starts the MCP bridge eagerly (session start)
+2. The bridge waits 15 seconds for the LSP sidecar's port file
+3. The LSP starts lazily (first `.ivy` file access) — port file never appears in time
+4. The bridge falls back to standalone MCP, but the combined startup time (~32s) causes Claude Code to kill the process (via orphan detection or stdio timeout)
+
+**Result:** MCP tools (`ivy_capabilities`, `ivy_diagnostics`, `ivy_coverage`, etc.) are never available, even though the plugin's skills, commands, and agents work fine.
+
+## Solution: Lazy Bridge
+
+Replace the blocking `mcp-bridge` mode with a standalone MCP server that upgrades to bridge mode transparently when the LSP sidecar becomes available.
+
+### Architecture
+
+```
+Phase 1 (0-10s):   MCP starts standalone → loads .ivy-index/ cache → [MCP-READY]
+Phase 2 (background): polls for sidecar port file (2s initially, 10s after 60s)
+Phase 3 (transparent): validates workspace match → delegates tools via MCP client → [UPGRADED]
+```
+
+The MCP server is **always a standalone stdio MCP server**. The "upgrade" is internal — tool calls are forwarded to the LSP sidecar's MCP HTTP endpoint via an MCP client connection. No stdio relay, no process switching.
+
+```
+Claude Code
+  ├─ LSP (.lsp.json) → IvyLanguageServer + MCP HTTP sidecar thread
+  │                     (starts on first .ivy file access)
+  │                     └─ writes /tmp/ivy-mcp-{hash}.port
+  │
+  └─ MCP (.mcp.json) → standalone MCP (fast start, offline index)
+                        └─ background: detects sidecar → upgrades to HTTP delegation
+```
+
+### Comparison with current architecture
+
+| Aspect | Current (broken) | New (lazy bridge) |
+|--------|-----------------|-------------------|
+| `.mcp.json` mode | `mcp-bridge` | `mcp` |
+| Startup time | ~32s (killed before ready) | ~10-15s |
+| Initial data source | N/A (never starts) | Offline `.ivy-index/` cache |
+| Live state sharing | Never achieved | Automatic when LSP sidecar detected |
+| Sidecar failure | Fatal (bridge crashes) | Transparent fallback to local |
+| Inter-process coupling | Tight (port file + HTTP + stdio relay) | Loose (optional HTTP delegation) |
+
+## Design Details
+
+### 1. Startup Flow
+
+**`.mcp.json` change:**
+```json
+{
+  "mcpServers": {
+    "ivy-tools": {
+      "command": "bash",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/start-ivy-server.sh",
+        "--mode",
+        "mcp"
+      ],
+      "env": { ... }
+    }
+  }
+}
+```
+
+**`start-ivy-server.sh` changes:**
+- Remove the `mcp-bridge` block (lines 93-135) that waits for the sidecar port file
+- Remove the `--mode mcp` deprecation notice (lines 29-33) — standalone MCP is now the primary mode
+- Remove `mcp-bridge` from the argument validation (line 22)
+- The `--mode mcp` launch path (lines 184-192) is unchanged
+
+### 2. Upgrade Mechanism (Tool Delegation via MCP Client)
+
+The existing tool registration uses `FastMCP` with `@mcp.tool()` decorators and a `safe_tool` wrapper in `ivy_lsp/tools/__init__.py`. The upgrade mechanism intercepts at the `safe_tool` level, not at a centralized dispatch point.
+
+**Integration approach:** Modify the `safe_tool` decorator to check a module-level `_sidecar_client` reference. When set, the wrapper short-circuits the local handler and forwards the call to the sidecar via the `mcp` library's client-side `call_tool()` method. The sidecar's response is returned **verbatim** — no local `_format_result` or timeout tracking is applied (the sidecar's own `safe_tool` handles that).
+
+```python
+# In mcp_server.py — module-level state
+_sidecar_client: Optional[ClientSession] = None  # None = standalone mode
+
+def safe_tool(fn):
+    """Decorator wrapping tool handlers with error handling + sidecar delegation."""
+    @wraps(fn)
+    async def wrapper(*args, **kwargs):
+        # Phase 3: delegate to sidecar if available
+        client = _sidecar_client
+        if client is not None:
+            try:
+                result = await client.call_tool(fn.__name__, kwargs)
+                return result  # verbatim, no local formatting
+            except Exception:
+                logger.warning("[DOWNGRADED] Sidecar call to %s failed, using local", fn.__name__)
+                _set_sidecar_client(None)
+                # Fall through to local handling
+
+        # Phase 1: local handling with offline index
+        try:
+            return _format_result(await fn(*args, **kwargs))
+        except Exception as exc:
+            return _format_error(exc)
+    return wrapper
+```
+
+**Background sidecar monitor** (started as `asyncio.create_task()` after MCP initialization):
+
+```python
+async def _sidecar_monitor(workspace_root: str):
+    """Poll for sidecar port file, validate workspace, upgrade when ready."""
+    poll_interval = 2.0  # fast polling for first 60s
+    elapsed = 0.0
+
+    while True:
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+        # Progressive backoff: 2s for first 60s, then 10s
+        if elapsed > 60 and poll_interval < 10:
+            poll_interval = 10.0
+
+        port = _read_port_file(workspace_root)
+        if port is None:
+            continue
+
+        # Validate workspace match before upgrading
+        if not await _validate_sidecar_workspace(port, workspace_root):
+            logger.debug("Sidecar workspace mismatch, skipping")
+            continue
+
+        if await _health_check(port):
+            client = await _connect_to_sidecar(port)
+            if client:
+                _set_sidecar_client(client)
+                logger.info("[UPGRADED] Delegating to LSP sidecar on port %d", port)
+                # Keep polling at slow rate to detect sidecar restarts
+                poll_interval = 30.0
+```
+
+**Workspace validation:** Before upgrading, the monitor hits the sidecar's `/health` endpoint and compares the returned workspace root against its own. This prevents upgrading to a sidecar from a different session/worktree that happens to use the same workspace hash.
+
+**Key properties:**
+- Uses existing `streamablehttp_client` from the `mcp` library (already a dependency)
+- Sidecar response is returned verbatim — no double-formatting or double-timeout
+- `_set_sidecar_client()` is a simple reference swap (atomic under CPython GIL)
+- The monitor validates workspace match before upgrading
+
+### 3. Error Handling
+
+**Sidecar never appears** (user never opens `.ivy` file):
+- MCP runs standalone for entire session using offline index
+- Background monitor polls at 2s initially, 10s after 60s (low overhead: one file stat)
+- This is the common case for short sessions
+
+**Sidecar appears then dies** (LSP crashes):
+- `safe_tool` wrapper catches connection errors from sidecar client
+- Sets `_sidecar_client = None` → reverts to local handling
+- Logs `[DOWNGRADED] Sidecar lost, reverting to local handling`
+- Monitor continues polling — will re-upgrade if sidecar restarts
+
+**Post-downgrade degraded results:**
+After reverting from sidecar to local handling, model-dependent tools may return degraded results (e.g., `"state": "not_built"`) until the local model prewarm/lazy-build completes. This is expected behavior and self-resolves within seconds as the local model initializes. The degradation window is brief because the offline index is still loaded — only the live SemanticModel needs rebuilding.
+
+**Tool call during upgrade transition:**
+- Reference swap is atomic (`_sidecar_client = client`, CPython GIL)
+- An in-flight local handler continues to completion on the local path
+- The next `safe_tool` invocation reads the new reference and delegates to sidecar
+- No locking needed — consistency concern is limited to the brief overlap, not data corruption
+
+**Stale port file from previous session:**
+- The sidecar monitor validates the sidecar's workspace root via the `/health` endpoint before upgrading
+- If the workspace root doesn't match, the upgrade is skipped
+- The `/health` endpoint already returns workspace metadata (added in this design if not present)
+
+**SIGTERM / orphan detection (the original killer):**
+- With fast standalone startup (~10s), MCP responds to the initialization handshake well within the 60s timeout
+- The orphan watchdog (checks parent PID every 5s) never triggers because the process is healthy and responsive
+
+### 4. File Changes
+
+| File | Change |
+|------|--------|
+| `.mcp.json` | `--mode mcp-bridge` → `--mode mcp` |
+| `start-ivy-server.sh` | Remove `mcp-bridge` block (lines 93-135). Remove deprecation notice for `--mode mcp` (lines 29-33). Remove `mcp-bridge` from argument validation (line 22). |
+| `mcp_server.py` | Add `_sidecar_client` module state, `_sidecar_monitor()` background task, workspace validation |
+| `tools/__init__.py` | Modify `safe_tool` decorator to check `_sidecar_client` and delegate when set |
+| `mcp_sidecar.py` | Ensure `/health` endpoint returns `workspace_root` for validation |
+| `mcp_bridge.py` | No changes (kept for backward compat / CI usage) |
+| `.lsp.json` | No changes |
+| `ivy-lsp-wrapper.sh` | Delete. Only referenced in a comment in `workspace-common.sh` (line 3). No `.lsp.json`, hook, or script uses it. Update the comment. |
+
+### 5. Validation Plan
+
+1. **Fast startup**: Start fresh Claude Code session → MCP tools appear within ~15s
+2. **Health check**: Run `/nct-health` → Steps 4-6 (MCP server alive, Workspace access, Model builds) PASS
+3. **Upgrade detection**: Open an `.ivy` file (triggers LSP + sidecar) → check MCP log for `[UPGRADED]` message
+4. **Fallback resilience**: Kill the LSP → next MCP tool call works locally with `[DOWNGRADED]` in log
+5. **Clean session**: No stale PID or port files accumulate across sessions
+6. **Wrong-workspace rejection**: Start two worktree sessions → verify MCP does not upgrade to the other session's sidecar
+
+### 6. Rollback Strategy
+
+**Full rollback** (restore original bridge behavior): Revert both `.mcp.json` (back to `--mode mcp-bridge`) AND `start-ivy-server.sh` (restore the `mcp-bridge` argument validation and wait/fallback block). Both changes are required — reverting only `.mcp.json` without restoring the shell script's `mcp-bridge` handling will fail at argument validation. `mcp_bridge.py` is preserved in the ivy-lsp package for this purpose.
+
+**Lightweight disable** (keep standalone, skip upgrade): Set env var `IVY_MCP_DISABLE_UPGRADE=1` to skip the sidecar monitor entirely. MCP stays standalone for the whole session. No code revert needed.
+
+## Constraints
+
+- The MCP timeout in Claude Code defaults to 60 seconds (`MCP_TIMEOUT` env var, in milliseconds). Configurable but timeouts >60s may not be respected reliably.
+- The offline `.ivy-index/` cache must be reasonably fresh. The index is built by the `ivy_lsp index` CLI command and/or the LSP server's indexing pipeline. Stale index means stale MCP results until upgrade.
+- A few seconds of staleness between LSP edits and MCP tool results is acceptable (confirmed by user).
+
+## Out of Scope
+
+- Removing `mcp_bridge.py` entirely (kept for backward compat / rollback)
+- Changing the LSP startup behavior (remains lazy, on-demand)
+- Modifying the offline index format or update mechanism
+- Addressing the uvx build-from-source latency (orthogonal optimization)

--- a/docs/superpowers/specs/2026-03-20-serena-single-gateway-design.md
+++ b/docs/superpowers/specs/2026-03-20-serena-single-gateway-design.md
@@ -1,0 +1,556 @@
+# Serena as Single MCP Gateway for Ivy Tools
+
+**Date**: 2026-03-20
+**Status**: Design — Approved
+**Branch**: `refactor/ivy-lsp-cleanup` (worktree: `lsp-to-claude`)
+**Supersedes**: MCP tool sections of `panther-ivy-serena-plugin-design.md`, WS2 of `ivy-lsp-indexing-improvements-design.md`
+**Depends on**: `unified-workspace-offline-indexing-design.md` (2026-03-20, status: Draft — must be finalized before Phase 3)
+
+---
+
+## 1. Problem Statement
+
+The current architecture has three overlapping tool surfaces:
+
+1. **ivy-lsp MCP sidecar** — 18 tools exposed via HTTP (FastMCP), running as a daemon thread inside the ivy-lsp process. This is the primary tool surface used by Claude Code via `.mcp.json`.
+2. **panther-serena** — Fork of Serena with 4 Ivy-specific tools (IvyDiagnosticsTool, IvyGotoDefinitionTool, IvyServerStatusTool, IvyTestScopeTool) plus standard Serena tools (find_symbol, get_symbols_overview, replace_symbol_body, etc.). **Not registered** in the plugin — completely inaccessible from Claude Code.
+3. **panther-ivy-plugin CLAUDE.md** — References `mcp__ivy-tools__*` tool names, but the original design doc references `mcp__plugin_serena_serena__*` names for tools that were removed from Serena (IvyCheckTool, IvyCompileTool, IvyModelInfoTool — removed in commit 78ca022d).
+
+### Specific issues
+
+- **Serena's value is inaccessible**: Semantic code editing (replace_symbol_body, insert_after_symbol), project memory, and symbol navigation are not available from Claude Code.
+- **Design doc is stale**: `panther-ivy-serena-plugin-design.md` references removed Serena tools and wrong MCP tool names.
+- **Serena's `.serena/project.yml` doesn't list Ivy**: Languages are `[python, typescript]` — IvyLanguageServer is never activated.
+- **Double-server risk**: Plugin's `.lsp.json` starts ivy-lsp; Serena would start its own ivy-lsp subprocess.
+- **No workspace adaptation**: Serena has no concept of `.ivyworkspace`, test scopes, include closures, or per-mirror scoping.
+
+---
+
+## 2. Decision
+
+**Serena becomes the single MCP gateway.** All Ivy tools are Serena `Tool` subclasses backed by a shared `ivy_tools` library extracted from ivy-lsp. The ivy-lsp MCP sidecar is removed after migration.
+
+### Why Serena (not ivy-lsp MCP)
+
+- **Semantic code editing**: `replace_symbol_body`, `insert_after_symbol`, `insert_before_symbol` provide LSP-aware code modification for Ivy files — something neither ivy-lsp MCP nor Claude Code's native Edit tool offers.
+- **Project management**: Serena's memory system (`.serena/memories/`), project activation, and onboarding provide persistent project context across sessions.
+- **Unified tool surface**: One MCP server for everything — verification, analysis, navigation, editing, memory.
+
+### Why shared library (not re-implementation)
+
+- **No duplication**: One implementation of verification, coverage, diagnostics, etc.
+- **No drift**: ivy-lsp's LSP features and Serena's tools use the same computation functions.
+- **Shared cache**: `.ivy-index/` on disk, read by both ivy-lsp (fast startup) and Serena tools.
+
+---
+
+## 3. Architecture
+
+### 3.1 Package Structure & Dependency Direction
+
+**Critical constraint**: `ivy_tools` is the foundational library. `ivy_lsp` depends on `ivy_tools`, never the reverse. This means all shared parsing, analysis, and data structures live in `ivy_tools`. `ivy_lsp` is a thin LSP protocol layer that wires pygls to `ivy_tools`' analysis functions.
+
+```
+Dependency graph:
+  ivy_tools  ← imported by ← ivy_lsp
+  ivy_tools  ← imported by ← panther-serena
+  (ivy_tools has NO dependency on ivy_lsp or serena)
+```
+
+```
+ivy-lsp/                              # Git submodule
+├── ivy_tools/                        # Package 1: Shared analysis & tool library (NEW)
+│   ├── __init__.py                   # Public API
+│   ├── context.py                    # IvyToolContext (see Section 3.5)
+│   ├── parsing/                      # TieredExtractor (parser→lexer→regex) — MOVED from ivy_lsp
+│   ├── analysis/                     # TestScope, requirement analysis — MOVED from ivy_lsp
+│   ├── semantic/                     # SemanticModel, RequirementGraph, rfc_annotations — MOVED
+│   ├── workspace/                    # WorkspaceContext, ProtocolIndex, .ivyworkspace parser — MOVED
+│   │   ├── context.py                # WorkspaceContext, ProtocolIndex
+│   │   ├── test_scope.py             # TestScope class
+│   │   └── config.py                 # .ivyworkspace parser
+│   ├── indexer/                      # WorkspaceIndexer, include resolution — MOVED from ivy_lsp
+│   ├── verification.py               # run_ivy_check, run_ivy_compile, run_ivy_show + LRU cache
+│   ├── diagnostics.py                # Structural lint + full 5-layer pipeline
+│   ├── coverage.py                   # Coverage stats/gaps/matrix/diff
+│   ├── include_graph.py              # Include graph reconstruction
+│   ├── visualization.py              # Dependency graphs, state machines, layer views
+│   ├── patterns.py                   # Pattern analysis/validation/scaffolding
+│   ├── quality.py                    # Quality gates + suggestions
+│   ├── traceability.py               # RFC extraction, manifest management
+│   ├── capabilities.py               # System capability checks, health check
+│   ├── staging.py                    # Layer-aware staging path resolution
+│   ├── formatters.py                 # JSON→Markdown formatting
+│   └── _safe_call.py                 # Timeout, concurrency, metrics decorator
+│
+├── ivy_lsp/                          # Package 2: Pure LSP server (pygls) — SLIMMED
+│   ├── server.py                     # IvyLanguageServer — imports ivy_tools for analysis
+│   ├── __main__.py                   # Entry point (--mcp flag removed)
+│   └── features/                     # 19 LSP features — import ivy_tools.parsing, .semantic, etc.
+│
+└── pyproject.toml                    # Exports: ivy_tools (standalone), ivy_lsp (depends on ivy_tools)
+
+panther-serena/                       # Git submodule (fork)
+├── src/serena/tools/
+│   ├── ivy_tools.py                  # 20 Serena Tool subclasses (18 new + 2 kept)
+│   └── ivy_workspace.py              # .ivyworkspace parsing, Serena ProjectConfig adapter
+├── src/solidlsp/language_servers/
+│   └── ivy_language_server.py        # Extended: custom LSP requests for live state
+└── pyproject.toml                    # Adds ivy-tools dependency
+
+panther-ivy-plugin/                   # Git submodule
+├── .mcp.json                         # serena MCP server (replaces ivy-tools)
+├── .lsp.json                         # ivy-lsp for editor diagnostics (kept)
+├── scripts/start-serena.sh           # New startup script
+└── ...                               # Agents, skills, commands, hooks
+```
+
+### 3.2 Three-Layer Sharing Model
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  LAYER 1: Shared Code (ivy_tools library)                    │
+│                                                               │
+│  TieredExtractor, WorkspaceContext, SemanticModel,           │
+│  RequirementGraph, TestScope, verification functions,        │
+│  coverage computation, pattern analysis, formatters          │
+│                                                               │
+│  ivy_tools has ZERO dependency on ivy_lsp or Serena.         │
+│  ivy_lsp imports ivy_tools. Serena imports ivy_tools.        │
+│  Single implementation, two consumers.                       │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  LAYER 2: Shared Disk Cache (.ivy-index/ directories)        │
+│                                                               │
+│  Built once (ivy_index CLI or session start hook)            │
+│  Contains: manifest, symbols, includes, exports,            │
+│  requirements, serialized semantic model, test scopes,       │
+│  requirement graph snapshot                                  │
+│                                                               │
+│  Read by BOTH ivy-lsp (fast startup) AND Serena tools        │
+│  Staleness: manifest mtime vs source file mtimes             │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  LAYER 3: Live State via Custom LSP Requests                 │
+│  (Tier 4 model-dependent tools only)                         │
+│                                                               │
+│  ivy-lsp exposes:                                            │
+│    ivy/getCoverageData → pre-computed coverage for scope     │
+│    ivy/getVisualization → pre-computed graph data            │
+│    ivy/getModelSummary → pre-computed summary                │
+│                                                               │
+│  Serena calls via IvyLanguageServer.send_custom_request()    │
+│  Computation runs in ivy-lsp process (live model)            │
+│  Fallback when .ivy-index is stale                           │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 Data Flow
+
+```
+User calls mcp__serena__ivy_coverage(mode="stats", test_file="quic_server_test.ivy")
+  │
+  ▼
+Serena IvyCoverageTool.apply()
+  │
+  ├── Try Layer 2: ivy_tools.coverage.compute_stats(workspace_context_from_index)
+  │     └── If .ivy-index fresh (mtime OK) → return result
+  │
+  └── Fallback Layer 3: ivy_ls.send_custom_request("ivy/getCoverageData", params)
+        └── ivy-lsp runs ivy_tools.coverage.compute_stats(live_model) → return
+```
+
+### 3.4 Serena Workspace Adaptation
+
+New file `src/serena/tools/ivy_workspace.py`:
+
+```
+IvyWorkspaceAdapter
+  ├── Loads .ivyworkspace         via ivy_tools.workspace.parse_workspace_config()
+  ├── Loads .ivy-index/           via ivy_tools.workspace.load_context()
+  ├── list_test_scopes()          all endpoint mirrors
+  ├── get_test_scope(name)        TestScope with include closure
+  ├── get_active_scope()          currently selected scope
+  ├── resolve_include(path)       layer-aware include resolution
+  └── list_protocols()            available protocols
+```
+
+Serena's standard tools (find_symbol, get_symbols_overview, etc.) work as-is — they delegate to LSP which already handles scoping. No modification to standard Serena tools required.
+
+### 3.5 IvyToolContext (Dependency Injection)
+
+`ivy_tools/context.py` defines `IvyToolContext` — the replacement for the MCP sidecar's `ToolContext`. It is the single dependency injection point that all `ivy_tools` functions receive. Serena constructs it from the `IvyWorkspaceAdapter`; ivy-lsp constructs it from its server state.
+
+```python
+@dataclass
+class IvyToolContext:
+    """Dependency injection for ivy_tools functions. No ivy_lsp imports."""
+    workspace_root: str
+    staging_dir: str | None = None
+    ivy_index_dir: str | None = None              # Path to .ivy-index/ (Layer 2 cache)
+
+    # Lazy callables — set by the consumer (Serena or ivy-lsp)
+    find_ivy_files: Callable[..., list[str]]       # File discovery
+    resolve_include: Callable[[str], str | None]   # Include path resolution
+    get_basename_cache: Callable[..., dict]         # Filename→paths mapping
+
+    # Tier 4 only — may be None for Tier 1-3 tools
+    get_model_snapshot: Callable[..., dict | None] = None   # Serialized SemanticModel
+    get_graph_snapshot: Callable[..., dict | None] = None   # Serialized RequirementGraph
+    get_test_scope: Callable[[str], Any | None] = None      # TestScope lookup
+```
+
+**Serena constructs it** in `IvyWorkspaceAdapter.make_tool_context()` — from `.ivy-index/` + ivy-lsp LSP fallback.
+**ivy-lsp constructs it** in `server.py` — from live in-memory state (for its own LSP features and custom LSP request handlers).
+
+---
+
+## 4. Tool Inventory
+
+**Total: 20 Ivy tools** (18 new ivy_tools-backed + 2 existing LSP wrappers kept as-is).
+
+### 4.1 Tier Definitions
+
+| Tier | Name | Dependencies | Layer Used |
+|---|---|---|---|
+| 1 | Subprocess | CLI subprocess calls + file I/O only | Layer 1 (code) |
+| 2 | Static Analysis | TieredExtractor + file scanning from `.ivy-index/` | Layer 1 + 2 (code + disk cache) |
+| 3 | Workspace-Aware | WorkspaceContext, TestScope lookup, manifest | Layer 1 + 2 (code + disk cache) |
+| 4 | Semantic Model | SemanticModel + RequirementGraph | Layer 1 + 2 + 3 (code + disk + LSP fallback) |
+
+### 4.2 New Serena Tool Classes (18 tools backed by ivy_tools)
+
+| Serena Tool Class | ivy_tools Function | Tier | Parameters |
+|---|---|---|---|
+| `IvyVerifyTool` | `verification.run_ivy_check()` | 1 | relative_path, isolate, scope |
+| `IvyCompileTool` | `verification.run_ivy_compile()` | 1 | relative_path, target, isolate, scope |
+| `IvyModelInfoTool` | `verification.run_ivy_show()` | 1 | relative_path, isolate |
+| `IvyCapabilitiesTool` | `capabilities.check_system()` | 1 | — |
+| `IvyExtractRequirementsTool` | `traceability.extract_requirements()` | 1 | rfc_source, sections, rfc_name, output |
+| `IvyPatternScaffoldTool` | `patterns.scaffold()` | 1 | protocol, pattern |
+| `IvyIndexTool` | `workspace.build_index()` | 1 | protocol, mode |
+| `IvyHealthCheckTool` | `capabilities.health_check()` | 1 | — |
+| `IvyIncludeGraphTool` | `include_graph.compute()` | 2 | relative_path, scope |
+| `IvyDiagnosticsTool` | `diagnostics.run()` | 2 | relative_path, mode, layers, min_severity |
+| `IvyPatternsTool` | `patterns.analyze()` | 2 | protocol, pattern, mode |
+| `IvyVerificationDashboardTool` | `verification.dashboard()` | 2 | — |
+| `IvyScopeTool` | `workspace.get_scope_info()` | 3 | relative_path, action |
+| `IvyManifestTool` | `traceability.manage_manifest()` | 3 | scope, mode |
+| `IvyQualityTool` | `quality.check_gate()` / `quality.suggest()` | 3/4 | file_path, mode, protocol, gate_level |
+| `IvyCoverageTool` | `coverage.compute()` | 4 | relative_path, test_file, scope, protocol, mode |
+| `IvyVisualizeTool` | `visualization.render()` | 4 | test_file, protocol, view |
+| `IvyModelSummaryTool` | `visualization.summarize()` | 4 | test_file, action_name, file_path, detail |
+
+### 4.3 Existing Serena Tools (kept as-is, no code changes needed)
+
+| Tool | Reason |
+|---|---|
+| `IvyGotoDefinitionTool` | Pure LSP wrapper — no ivy_tools equivalent. Already works. |
+| `IvyServerStatusTool` | LSP custom request (`ivy/serverStatus`) — server introspection. Already works. |
+
+These two tools exist today and require zero modification. They are listed in `included_optional_tools` to ensure they're enabled for Ivy projects.
+
+### 4.4 Existing Serena Tools (merged into new tools)
+
+| Old Tool | Merged Into | Mode Mapping |
+|---|---|---|
+| `IvyDiagnosticsTool` (cached LSP) | New `IvyDiagnosticsTool` | `mode="cached"` → returns LSP publishDiagnostics cache (existing behavior). `mode="structural"` → ivy_tools structural lint. `mode="full"` → ivy_tools 5-layer pipeline. |
+| `IvyTestScopeTool` | `IvyScopeTool` | `action="list"/"set"` → LSP test scope management (existing behavior). `action="info"` → ivy_tools workspace scope info (new). |
+
+### 4.5 Standard Serena Tools (available for Ivy)
+
+These require no modification — they work via LSP:
+
+| Tool | Purpose for Ivy |
+|---|---|
+| `find_symbol` | Locate Ivy symbols (actions, types, relations) by name |
+| `get_symbols_overview` | Display structure of an .ivy file |
+| `find_referencing_symbols` | Find where a symbol is referenced across .ivy files |
+| `replace_symbol_body` | Edit the body of an Ivy action/type/relation in-place |
+| `insert_after_symbol` | Insert content after an Ivy symbol definition |
+| `insert_before_symbol` | Insert content before an Ivy symbol definition |
+| `read_file` | Read .ivy file contents |
+| `create_text_file` | Create new .ivy files |
+| `search_for_pattern` | Regex search across Ivy codebase |
+| `write_memory` / `read_memory` | Persist project knowledge |
+
+---
+
+## 5. Plugin Changes
+
+### 5.1 `.mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "command": "bash",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/start-serena.sh"],
+      "env": {
+        "IVY_LSP_LOG_LEVEL": "DEBUG",
+        "SERENA_PROJECT_ROOT": "${CLAUDE_PLUGIN_ROOT}/../../.."
+      }
+    }
+  }
+}
+```
+
+### 5.2 `.lsp.json` — Kept as-is
+
+Two ivy-lsp instances run: one from `.lsp.json` (editor diagnostics push), one from Serena (tool surface). Both read from `.ivy-index/` for fast startup.
+
+**Memory cost**: Both instances build in-memory semantic models (2-4 minute cold start each). This is acceptable because:
+- `.ivy-index/` pre-built index significantly reduces cold start time (the unified-workspace-offline-indexing spec addresses this)
+- The `.lsp.json` instance is lightweight — it only needs the model for interactive features (hover, definition)
+- Serena's instance is the primary workhorse — Tier 1-3 tools don't need the model at all; only Tier 4 tools trigger model building, and they can use the `.ivy-index/` cached snapshot first
+- If memory is a concern, Serena's ivy-lsp instance can be started with `--light-mode` (skip eager model building, build on-demand only for Tier 4 fallback)
+
+### 5.3 `.serena/project.yml` — New file at panther_ivy root
+
+Note: `included_optional_tools` uses Serena's tool naming convention (snake_case of class name minus `Tool` suffix). Verify against Serena's `ToolRegistry` auto-discovery logic during Phase 0.
+
+```yaml
+project_name: "panther-ivy"
+languages:
+  - ivy
+ignored_paths:
+  - "submodules/z3/**"
+  - "submodules/picotls/**"
+  - "submodules/abc/**"
+  - "submodules/aiger/**"
+  - "doc/**"
+  - "examples/**"
+  - "patches/**"
+ignore_all_files_in_gitignore: true
+read_only: false
+included_optional_tools:
+  - ivy_verify
+  - ivy_compile
+  - ivy_model_info
+  - ivy_diagnostics
+  - ivy_include_graph
+  - ivy_capabilities
+  - ivy_coverage
+  - ivy_extract_requirements
+  - ivy_manifest
+  - ivy_visualize
+  - ivy_model_summary
+  - ivy_patterns
+  - ivy_pattern_scaffold
+  - ivy_quality
+  - ivy_scope
+  - ivy_health_check
+  - ivy_index
+  - ivy_verification_dashboard
+  - ivy_goto_definition
+  - ivy_server_status
+```
+
+### 5.4 MCP Tool Name Convention
+
+Claude Code plugin MCP tools are namespaced as `mcp__plugin_<plugin-name>_<server-name>__<tool>`. With the `.mcp.json` server named `serena` in the `panther-ivy-plugin` plugin, the actual tool names will be:
+
+```
+mcp__plugin_panther-ivy-plugin_serena__ivy_verify
+mcp__plugin_panther-ivy-plugin_serena__find_symbol
+mcp__plugin_panther-ivy-plugin_serena__replace_symbol_body
+...
+```
+
+For brevity, this spec uses `mcp__serena__*` as shorthand. All references to tool names in CLAUDE.md, hooks, commands, and other docs must use the full qualified name.
+
+### 5.5 `start-serena.sh` Script
+
+New script replacing `start-ivy-server.sh` for the MCP server. Responsibilities:
+
+1. Activate the panther_ivy virtualenv (or use `uvx`)
+2. Detect workspace root via existing detection logic (`.ivyworkspace` search)
+3. Set `IVY_WORKSPACE_ROOT` env var (consumed by Serena's `IvyWorkspaceAdapter`)
+4. Run `uv run serena-mcp-server --project-root $SERENA_PROJECT_ROOT`
+
+Unlike `start-ivy-server.sh`, this script does NOT manage PID files or session scoping — Serena handles its own lifecycle. Log output goes to Serena's default log location.
+
+### 5.6 Hook Changes
+
+`block-direct-ivy` hook: tool name references change to the full qualified `mcp__plugin_panther-ivy-plugin_serena__*` prefix.
+
+### 5.7 CLAUDE.md
+
+All tool name references updated to full qualified prefix. Add documentation for Serena-only tools (find_symbol, replace_symbol_body, memory tools).
+
+---
+
+## 6. Phased Implementation Plan
+
+### Phase 0: Foundation
+
+**Goal**: Extract `ivy_tools` package, wire Serena MCP, verify no regressions.
+
+**Tasks** (ivy-lsp side):
+1. Create `ivy_tools/` package directory in ivy-lsp repo with `__init__.py`
+2. Move `parsing/` (TieredExtractor, lexer, regex fallback) to `ivy_tools/parsing/`
+3. Move `analysis/` (TestScope, requirement analysis) to `ivy_tools/analysis/`
+4. Move `semantic/` (SemanticModel, RequirementGraph, rfc_annotations) to `ivy_tools/semantic/`
+5. Move `workspace_context.py` + `indexer/` to `ivy_tools/workspace/` and `ivy_tools/indexer/`
+6. Move `verification.py` (run_ivy_check, run_ivy_compile, run_ivy_show) to `ivy_tools/verification.py`
+7. Move staging logic (resolve_staging_path, layer resolution) to `ivy_tools/staging.py`
+8. Move formatters to `ivy_tools/formatters.py`
+9. Move timeout/metrics decorator to `ivy_tools/_safe_call.py`
+10. Create `ivy_tools/context.py` with `IvyToolContext` class (Section 3.5)
+11. Update ALL ivy-lsp imports: `ivy_lsp.parsing` → `ivy_tools.parsing`, etc.
+12. Update `pyproject.toml`: export `ivy_tools` (standalone) and `ivy_lsp` (depends on ivy_tools)
+13. Verify all existing ivy-lsp tests pass (1965+ tests)
+
+**Tasks** (Serena + plugin side):
+14. Create `IvyWorkspaceAdapter` in `src/serena/tools/ivy_workspace.py`
+15. Create `start-serena.sh` script in panther-ivy-plugin
+16. Update `.mcp.json` to register Serena MCP server
+17. Create `.serena/project.yml` at panther_ivy root
+18. Add `ivy-tools` dependency to panther-serena `pyproject.toml`
+19. Verify Serena MCP server starts and standard tools work on .ivy files
+
+**Exit criteria**: `ivy_tools` is importable from both ivy-lsp and Serena. Serena MCP server starts and exposes standard tools. No regressions.
+
+### Phase 1: Subprocess Tools (8 tools)
+
+**Goal**: Basic "build and check" workflow through Serena.
+
+**Tasks**:
+1. Implement `IvyVerifyTool` — delegates to `ivy_tools.verification.run_ivy_check()`
+2. Implement `IvyCompileTool` — delegates to `ivy_tools.verification.run_ivy_compile()`
+3. Implement `IvyModelInfoTool` — delegates to `ivy_tools.verification.run_ivy_show()`
+4. Implement `IvyCapabilitiesTool` — delegates to `ivy_tools.capabilities.check_system()`
+5. Implement `IvyHealthCheckTool` — delegates to `ivy_tools.capabilities.health_check()`
+6. Implement `IvyExtractRequirementsTool` — delegates to `ivy_tools.traceability.extract_requirements()`
+7. Implement `IvyPatternScaffoldTool` — delegates to `ivy_tools.patterns.scaffold()`
+8. Implement `IvyIndexTool` — delegates to `ivy_tools.workspace.build_index()`
+9. Register all 8 as `ToolMarkerOptional` in Serena's tool registry
+10. Add tests for each tool (Serena test framework)
+
+**Exit criteria**: `mcp__serena__ivy_verify`, `mcp__serena__ivy_compile`, `mcp__serena__ivy_model_info` work end-to-end. `/nct-check` command works via Serena.
+
+### Phase 2: Static Analysis Tools (4 tools)
+
+**Goal**: Diagnostics, include analysis, and pattern checking through Serena.
+
+**Tasks** (TieredExtractor already in ivy_tools from Phase 0):
+1. Create `ivy_tools/diagnostics.py` — wire structural lint + full pipeline using `ivy_tools.parsing.TieredExtractor`
+2. Create `ivy_tools/include_graph.py` — include graph computation using `ivy_tools.indexer`
+3. Create `ivy_tools/patterns.py` — pattern analysis/validation using file scanning
+4. Implement `IvyDiagnosticsTool` — unified tool with 3 modes: `mode="cached"` (LSP publishDiagnostics), `mode="structural"` (ivy_tools lint), `mode="full"` (ivy_tools 5-layer)
+5. Implement `IvyIncludeGraphTool` — delegates to `ivy_tools.include_graph.compute()`
+6. Implement `IvyPatternsTool` — delegates to `ivy_tools.patterns.analyze()`
+7. Implement `IvyVerificationDashboardTool` — delegates to `ivy_tools.verification.dashboard()`
+8. Add tests (unit tests with mocked ivy_tools + integration test with real .ivy files from `test/resources/`)
+
+**Exit criteria**: `ivy_diagnostics(mode="structural")`, `ivy_diagnostics(mode="cached")`, and `ivy_include_graph` work via Serena. Pattern analysis works.
+
+**Exit criteria**: `ivy_diagnostics(mode="structural")` and `ivy_include_graph` work via Serena. Pattern analysis works.
+
+### Phase 3: Workspace-Aware Tools (3 tools)
+
+**Goal**: Scope-aware operations through Serena.
+
+**Tasks**:
+1. Move TestScope, ProtocolIndex to `ivy_tools/workspace.py`
+2. Move manifest management to `ivy_tools/traceability.py`
+3. Move quality gate logic to `ivy_tools/quality.py`
+4. Wire `IvyWorkspaceAdapter` to load `.ivy-index/` on Serena project activation
+5. Implement `IvyScopeTool` — merges existing `IvyTestScopeTool` (LSP) + workspace info (ivy_tools)
+6. Implement `IvyManifestTool` — delegates to `ivy_tools.traceability.manage_manifest()`
+7. Implement `IvyQualityTool` (gate mode) — delegates to `ivy_tools.quality.check_gate()`
+8. Add tests
+
+**Exit criteria**: `ivy_scope`, `ivy_manifest`, `ivy_quality(mode="gate")` work via Serena with test scope filtering.
+
+### Phase 4: Semantic Model Tools (3 tools + quality suggestions)
+
+**Goal**: Full tool parity. All 20 Serena tools operational.
+
+**Tasks** (ivy-lsp side):
+1. Create `ivy_tools/coverage.py` — coverage computation using `ivy_tools.semantic.SemanticModel` + `ivy_tools.semantic.RequirementGraph`
+2. Create `ivy_tools/visualization.py` — graph/summary generation using same
+3. Add custom LSP request handlers in ivy-lsp: `ivy/getCoverageData`, `ivy/getVisualization`, `ivy/getModelSummary`, `ivy/getQualitySuggestions` — each calls the corresponding `ivy_tools` function with live model and returns JSON
+
+**Tasks** (Serena side):
+4. Extend `IvyLanguageServer.send_custom_request()` to support the 4 new methods
+5. Implement Layer 2→3 fallback in `IvyWorkspaceAdapter`:
+   a. Staleness check: compare `.ivy-index/manifest.json` mtime vs source file mtimes
+   b. If fresh: load snapshot from `.ivy-index/` → pass to `ivy_tools` function
+   c. If stale: call `send_custom_request("ivy/get*")` → format result
+   d. If LSP unavailable: return error with "run ivy_index to refresh"
+6. Implement `IvyCoverageTool` — calls `ivy_tools.coverage.compute()` with fallback
+7. Implement `IvyVisualizeTool` — calls `ivy_tools.visualization.render()` with fallback
+8. Implement `IvyModelSummaryTool` — calls `ivy_tools.visualization.summarize()` with fallback
+9. Implement `IvyQualityTool` (suggestions mode) — always uses LSP (suggestions need live model)
+10. Add tests: unit tests with mock `.ivy-index/` snapshots + integration tests exercising Layer 3 fallback
+
+**Exit criteria**: All 20 tools work via Serena MCP. `ivy_coverage(mode="stats", test_file=...)` returns correct scoped results.
+
+### Phase 5: Cleanup & Plan Updates
+
+**Goal**: Remove ivy-lsp MCP, update all docs.
+
+**Tasks**:
+1. Remove `ivy_lsp/mcp_server.py` (standalone MCP entry)
+2. Remove `ivy_lsp/mcp_sidecar.py` (HTTP sidecar)
+3. Remove `ivy_lsp/tools/` directory
+4. Remove `--mcp` flag from `ivy_lsp/__main__.py`
+5. Remove MCP deps from ivy-lsp `pyproject.toml` (mcp, uvicorn, httpx)
+6. Update `panther-ivy-serena-plugin-design.md` — rewrite Sections 3.3 (commands), 4.2 (dependency), 4.3 (tool params), architecture diagram
+7. Update `unified-workspace-offline-indexing-design.md` — consumer = Serena via ivy_tools import
+8. Update `lsp-mcp-crash-resilience-design.md` — remove Phase 2 (MCP resilience)
+9. Update `layer-aware-mcp-staging` plan (`.superpowers/plans/2026-03-18-layer-aware-mcp-staging.md`) — target = ivy_tools/staging.py
+10. Update `nct-validate-redesign-design.md` — tool name prefix to full qualified
+11. Update `ivy-lsp-indexing-improvements-design.md` — remove WS2 (MCP tool design)
+12. Update plugin CLAUDE.md — all tool references to full qualified names
+13. Update hook scripts — tool name references to full qualified names
+14. Update all command definitions (`/nct-check`, `/nct-compile`, `/nct-model-info`) — tool invocations
+15. Run nct-validate end-to-end to confirm
+
+**Exit criteria**: ivy-lsp has no MCP code. All docs reference Serena. nct-validate passes.
+
+---
+
+## 7. Existing Plan Impact Matrix
+
+| Document | Impact | Change Summary |
+|---|---|---|
+| `panther-ivy-serena-plugin-design.md` | HIGH | Rewrite MCP tool mapping, architecture diagram. All tools now `mcp__serena__*`. |
+| `unified-workspace-offline-indexing-design.md` | HIGH | Consumer = Serena via ivy_tools import (not MCP sidecar via env vars). |
+| `lsp-mcp-crash-resilience-design.md` | HIGH | Phase 2 (MCP resilience) removed. Phase 1, 3 kept. |
+| `layer-aware-mcp-staging.md` (`.superpowers/plans/`) | MEDIUM | Staging logic moves to ivy_tools/staging.py. Same algorithm, new location. |
+| `nct-validate-redesign-design.md` | MEDIUM | Tool name prefix: `mcp__ivy-tools__*` → `mcp__serena__*`. |
+| `ivy-lsp-indexing-improvements-design.md` | MEDIUM | WS2 (MCP tool design) removed. WS1 (core) kept. WS3 → ivy_tools. |
+| `requirement-coverage-redesign.md` | LOW | Implementation location: `ivy_tools.coverage` not `ivy_lsp.tools.traceability`. |
+| `pyright-like-diagnostics-design.md` | LOW | Stays in ivy-lsp. IvyDiagnostic format shared via ivy_tools. |
+| `nct-workspace-validation-design.md` | LOW | Layer 6 description update only. |
+| `ivy-plugin-evaluation-design.md` | LOW | Tool prefix change in test scenarios. |
+| `.superpowers/plans/*` | LOW | Tool name changes only. |
+
+---
+
+## 8. Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| Serena fork diverges further from upstream oraios/serena | Keep Ivy-specific code in `ivy_tools.py` and `ivy_workspace.py` — minimal Serena core changes |
+| Two ivy-lsp instances (`.lsp.json` + Serena) use memory | Both build in-memory models. `.ivy-index/` reduces cold start. Serena instance can use `--light-mode` to defer model building. See Section 5.2. |
+| ivy_tools extraction breaks ivy-lsp tests | Phase 0 gate: all 1965+ tests must pass before proceeding |
+| Custom LSP requests (Phase 4) add complexity | Layer 3 is fallback only — Layer 2 (.ivy-index/) handles most cases |
+| Serena startup slower (loads Ivy workspace) | Lazy initialization — IvyWorkspaceAdapter loads on first tool call, not on MCP server start |
+| Phase 4 tools require semantic model in Serena process | Solved by Layer 3 (custom LSP requests) — model stays in ivy-lsp process |
+
+---
+
+## 9. Success Criteria
+
+1. All 20 Ivy tools accessible via `mcp__serena__*` from Claude Code
+2. Standard Serena tools (find_symbol, replace_symbol_body, memory) work on .ivy files
+3. ivy-lsp is a pure LSP server — no MCP code, no tools/ directory
+4. No tool duplication — single implementation in `ivy_tools`
+5. `.ivy-index/` is the shared cache — no redundant model building
+6. All existing design specs updated with correct references
+7. nct-validate passes end-to-end with Serena as tool surface

--- a/docs/superpowers/specs/2026-03-20-unified-workspace-offline-indexing-design.md
+++ b/docs/superpowers/specs/2026-03-20-unified-workspace-offline-indexing-design.md
@@ -1,0 +1,502 @@
+# Unified Workspace & Offline Pre-Indexing Design
+
+**Date**: 2026-03-20
+**Status**: Draft
+**Scope**: ivy-lsp indexing, MCP/LSP workspace coherence, per-test scope views
+
+## Problem Statement
+
+The ivy-lsp system has three separate, incoherent workspace initialization paths:
+
+1. **SessionStart hook** (`detect-ivy-workspace.sh`) — bash-based detection, writes `IVY_WORKSPACE_ROOT` to env, outputs context to Claude
+2. **LSP server** (`.lsp.json` + `server.py`) — hardcoded env vars (`IVY_LSP_INCLUDE_PATHS`, `IVY_LSP_WORKSPACE_HINT`), builds full indexer from scratch (2-4 min cold start)
+3. **MCP server** (`start-ivy-tools.sh` + `mcp_server.py`) — re-detects workspace from `$PWD`, no indexer, stateless `_validate_path()` per tool call
+
+This causes:
+- **Redundant detection**: Three implementations of the same workspace-finding logic (two in bash, one in Python)
+- **MCP blindness**: MCP tools have no access to the symbol table, include graph, layer-aware staging, or test scope data that LSP maintains
+- **Slow cold starts**: LSP rebuilds the full index from scratch every session (~2-4 min for semantic model)
+- **No per-test scoping**: Tools operate on the full workspace even when the user is working on a single test's file set
+- **Incomplete model brittleness**: New protocols being built from scratch have no index, no scopes, and limited tool support
+
+## Architecture
+
+Three layers, each with a single responsibility:
+
+### Layer 1 — Offline Index Builder (`ivy-lsp index`)
+
+A CLI command that pre-computes a `.ivy-index/` directory at each protocol root. Uses the full Ivy parser (Tier 1) by default. Produces AST-quality symbols, include graphs, per-test scope closures, and requirement annotations.
+
+**Trigger**: Manual CLI command (Stage A). Designed to evolve toward git-event (B), session-start auto-rebuild (C), and file watcher (D) without changing the index format.
+
+### Layer 2 — Unified Workspace Context (`WorkspaceContext`)
+
+A single Python class that loads `.ivyworkspace` + all per-protocol `.ivy-index/` directories. Replaces the three separate detection paths. Consumed identically by LSP init, MCP init, and SessionStart hook.
+
+### Layer 3 — Session Overlay
+
+An in-memory dirty layer that tracks file creates/edits/deletes during a session. Overlays on top of the cached index. Supports multiple concurrent `TestScopeView` filters for different agents working on different test scopes simultaneously.
+
+### Data Flow
+
+```
+Offline:
+  ivy-lsp index → protocol-testing/<prot>/.ivy-index/ (per protocol)
+
+Session start:
+  .ivyworkspace + .ivy-index/* → WorkspaceContext
+    ├→ LSP server (loads index, skips fast-index, deep parse only for upgrades)
+    ├→ MCP server (loads same index, tools use it for resolution + scoping)
+    └→ SessionStart hook (reports workspace info + staleness to Claude)
+
+During session:
+  File edits → SessionOverlay → WorkspaceContext queries return merged results
+  Multiple views:
+    Agent A → TestScopeView("quic_server_test_reset") → 37 files
+    Agent B → TestScopeView("apt_quic_attacker_test") → 52 files
+    Both read from same WorkspaceContext with different scope filters
+```
+
+## Index Format
+
+### Protocol Definition & Isolation Model
+
+A "protocol" for indexing purposes is a **top-level directory** under `protocol-testing/` (e.g., `quic/`, `apt/`, `bgp/`, `coap/`). Each protocol owns its own `.ivy-index/` containing only files physically under that directory.
+
+**Protocols are self-contained. There are no cross-protocol file references.**
+
+APT is a complete parallel architecture that maintains its own **forked copies** of base protocol models:
+- `protocol-testing/apt/apt_protocols/quic/` has 184 `.ivy` files — forked copies of base QUIC with modifications (FSM omissions, type redefinitions, attack entity additions)
+- APT test files use ONLY APT-local includes — `include quic_types` resolves to APT's fork (`apt_protocols/quic/quic_stack/quic_types.ivy`), never to `protocol-testing/quic/quic_stack/quic_types.ivy`
+- `apt_shim.ivy` bridges `apt_types` and the forked `quic_types` within APT — both are APT-internal files
+
+This mirrors PANTHER's Docker execution model: each container mounts only ONE protocol tree, so there is no cross-protocol mixing at compilation time. The offline index must respect this isolation.
+
+**Consequences for indexing:**
+- Each `.ivy-index/` is truly independent — no `cross_protocol_deps` field needed
+- Files with the same basename across protocols (e.g., `quic_types.ivy` in both `quic/` and `apt/`) are indexed separately in their respective protocol indexes
+- Test scope closures never span protocol boundaries
+- The layer system within a protocol (e.g., `.ivyworkspace` layers `apt_core`, `apt_quic_fork`) handles intra-protocol collision routing
+
+**Symbol collisions** (e.g., `version`, `pkt_num`, `type_bits` declared in both `apt_types.ivy` and the forked `quic_types.ivy`) are an intentional APT design — `apt_shim.ivy` bridges these. The indexer records them as known collisions within the `apt` index, not as cross-protocol errors.
+
+### Directory Structure
+
+```
+protocol-testing/quic/.ivy-index/
+├── manifest.json                    # File inventory, mtimes, completeness, staleness
+├── symbols.json                     # IvySymbol.to_dict() per file (parser quality)
+├── includes.json                    # Include graph forward edges
+├── exports.json                     # ExportImportInfo.to_dict() per file
+├── requirements.json                # RFC annotations + requirement nodes
+├── semantic_model.pickle.gz         # Full SemanticModel graph (reuse shared_cache format)
+├── requirement_graph.pickle.gz      # ScopedRequirementModel (reuse shared_cache format)
+└── scopes/
+    ├── _meta.json                   # Test list, scope stats, coverage summary
+    └── <test_name>.json             # Per-test transitive closure
+```
+
+### Manifest Format
+
+```json
+{
+  "version": 1,
+  "protocol": "quic",
+  "created_at": "2026-03-20T14:30:00Z",
+  "builder_version": "0.5.0",
+  "default_parse_tier": "ast",
+  "files": {
+    "quic_stack/quic_packet.ivy": {
+      "mtime": 1742480000.0,
+      "size": 4523,
+      "sha256": "abc123...",
+      "completeness": "complete",
+      "parse_tier": "ast"
+    },
+    "quic_shims/quic_missing_shim.ivy": {
+      "mtime": null,
+      "completeness": "missing",
+      "referenced_by": ["quic_tests/server_tests/quic_server_test_reset.ivy"]
+    }
+  },
+  "known_collisions": {}
+}
+```
+
+For APT, known collisions would include the intentional symbol overlaps:
+```json
+{
+  "protocol": "apt",
+  "known_collisions": {
+    "quic_types.ivy": [
+      "apt_protocols/quic/quic_stack/quic_types.ivy"
+    ],
+    "quic_packet.ivy": [
+      "apt_protocols/quic/quic_stack/quic_packet.ivy"
+    ]
+  }
+}
+```
+
+- `completeness`: `complete` | `partial` (parse errors) | `missing` (dangling include target)
+- `parse_tier`: `ast` (Tier 1, full parser, default) | `lexer` (Tier 2, fast fallback)
+- `known_collisions`: basenames that appear multiple times within this protocol — the layer system resolves which variant to use
+
+### Per-Test Scope Format
+
+```json
+{
+  "test": "quic_server_test_reset",
+  "entry_file": "quic_tests/server_tests/quic_server_test_reset.ivy",
+  "role": "client",
+  "transitive_includes": [
+    "quic_stack/quic_packet.ivy",
+    "quic_stack/quic_connection.ivy",
+    "quic_shims/ivy_quic_shim_client_timeout.ivy"
+  ],
+  "layers_used": ["quic", "quic_tests"],
+  "dangling_includes": [],
+  "requirement_ids": ["rfc9000:4.1", "rfc9000:7.2"],
+  "completeness": "complete",
+  "file_count": 37
+}
+```
+
+### Serialization Strategy
+
+Reuses existing ivy-lsp infrastructure with minimal new code:
+
+| Data | Method | Source | New Code? |
+|------|--------|--------|-----------|
+| Per-file symbols | `IvySymbol.to_dict()` → JSON | `symbols.py` | No |
+| Export/import info | `ExportImportInfo.to_dict()` → JSON | `test_scope.py` | No |
+| Include graph edges | `{file: [module, ...]}` → JSON | `symbols.py` | `IncludeGraph.from_edges()` classmethod (new) |
+| SemanticModel | `pickle.gz` via `__getstate__` | `shared_cache.py` | No |
+| ScopedRequirementModel | `pickle.gz` | `shared_cache.py` | No |
+| Test scopes | JSON (from frozen `TestScope`) | `test_scope.py` | `TestScope.to_dict()` (new) |
+
+**Include graph**: `includes.json` stores raw forward edges (`{file: [included_module, ...]}`) as JSON. At load time, `IncludeGraph.from_edges(data)` reconstructs both forward and reverse maps. This is a new classmethod — the only structural serialization code needed.
+
+**ScopedRequirementModel**: The pickle file (`requirement_graph.pickle.gz`) contains a `ScopedRequirementModel` instance (extends `RequirementGraph`, includes test scope registration). The per-test JSON scope files in `scopes/` are a lightweight derived view for MCP tools that don't need the full graph. At load time, `WorkspaceContext` serves scope queries from JSON (fast, for MCP) or the full pickle (for LSP deep analysis).
+
+**Pickle version safety**: `WorkspaceContext` catches `pickle.UnpicklingError` and `AttributeError` on load. If the pickle was written by an incompatible `builder_version`, loading fails gracefully and falls through to live indexing with a warning to re-run `ivy-lsp index`.
+
+### Staleness Detection
+
+At session load, `WorkspaceContext` compares manifest mtimes against actual file mtimes:
+
+- **Fresh**: All mtimes match → load as-is
+- **Stale (minor)**: <10% files changed → log warning, load anyway (overlay handles edits)
+- **Stale (major)**: >10% or manifest missing → warn user, suggest `ivy-lsp index`
+
+### Error Recovery
+
+If individual index files are corrupt or missing:
+- **Corrupt JSON** (`symbols.json`, `includes.json`, etc.): catch `json.JSONDecodeError`, log warning, fall through to live indexing for that protocol
+- **Corrupt pickle** (`semantic_model.pickle.gz`): catch `pickle.UnpicklingError`/`AttributeError`, skip semantic model loading, MCP tools still work from JSON files
+- **Missing scope file**: scope reported as unavailable, can be rebuilt lazily from include graph
+- **Truncated manifest**: entire protocol index treated as missing, full fallback to live indexing
+
+The system never fails hard on index corruption — it always degrades to current behavior.
+
+### `.ivyworkspace` Schema
+
+The existing v3 `.ivyworkspace` schema is **sufficient** — no schema changes required. Discovery of `.ivy-index/` directories is implicit via filesystem glob (`protocol-testing/*/.ivy-index/manifest.json`). The workspace layers defined in `.ivyworkspace` are used by the index builder for layer-aware include resolution during the build process.
+
+## Unified Workspace Context
+
+### WorkspaceContext Class
+
+```
+WorkspaceContext
+├── workspace_root: str
+├── project_type: "panther" | "standalone" | "fallback"
+├── workspace_config: WorkspaceConfig        # From .ivyworkspace
+├── protocol_indexes: Dict[str, ProtocolIndex]
+├── overlay: SessionOverlay
+├── active_views: Dict[str, TestScopeView]
+│
+├── resolve_include(name, from_file) → str | None
+├── get_test_scope(test_name) → TestScope
+├── get_layer(file) → str | None
+├── list_tests(protocol=None) → List[str]
+├── list_protocols() → List[str]
+├── get_completeness(file) → "complete" | "partial" | "missing"
+├── create_view(name, test_name) → TestScopeView
+├── staleness_report() → Dict[str, StalenessInfo]
+```
+
+**StalenessInfo**: `{protocol: str, status: "fresh"|"stale_minor"|"stale_major", changed_files: int, total_files: int}`
+
+**CoverageStats**: `{total_requirements: int, covered: int, uncovered: int, percentage: float, by_level: Dict[str, int]}`
+
+### Canonical Loading Sequence
+
+Replaces all three detection paths with one function chain:
+
+```
+1. detect_workspace_root(start_dir)
+   → walks up for .ivyworkspace or PANTHER heuristic
+   → returns (root, project_type)
+
+2. load_workspace_config(root)
+   → reads .ivyworkspace (if exists)
+   → returns WorkspaceConfig with layers, excludes
+
+3. discover_protocol_indexes(root, config)
+   → globs protocol-testing/*/.ivy-index/manifest.json
+   → loads each ProtocolIndex (JSON files + pickle graphs)
+   → catches corruption gracefully per-protocol
+   → checks staleness, logs warnings
+
+4. WorkspaceContext(root, config, indexes)
+   → protocol indexes are independent (no cross-protocol merging)
+   → builds per-protocol include resolution chains
+```
+
+### Entry Point Simplification
+
+| Entry Point | Before | After |
+|-------------|--------|-------|
+| SessionStart hook | Bash detection (`detect-ivy-workspace.sh`) duplicates logic, sets env vars | Thin wrapper: calls `python -m ivy_lsp.workspace_context detect "$PWD"`, outputs JSON |
+| LSP server | `_setup_indexer()` → `_create_resolver()` → `detect_ivy_workspace()` → full scan | `WorkspaceContext.load(root)` → skip scan if index fresh |
+| MCP server | `start-ivy-tools.sh` re-detects from `$PWD`, no indexer | Reads `IVY_WORKSPACE_ROOT` from SessionStart env, receives `WorkspaceContext` |
+| start-ivy-tools.sh | Re-runs detection from scratch | Reads `IVY_WORKSPACE_ROOT`, passes to `--workspace` |
+
+**Bash hook migration**: `detect-ivy-workspace.sh` becomes a thin wrapper that calls the Python detection module. The bash `find_panther_ivy()` function and `workspace-common.sh` (if any) are deprecated. The Python module returns the same JSON structure the hook currently outputs.
+
+### Environment Variable Cleanup
+
+| Env Var | Status |
+|---------|--------|
+| `IVY_LSP_INCLUDE_PATHS` | **Deprecated** — sourced from `.ivyworkspace` |
+| `IVY_LSP_EXCLUDE_PATHS` | **Deprecated** — sourced from `.ivyworkspace` |
+| `IVY_LSP_WORKSPACE_HINT` | **Deprecated** — replaced by canonical detection |
+| `IVY_LSP_WORKSPACE` | **Kept** — explicit override (highest priority) |
+| `IVY_WORKSPACE_ROOT` | **Kept** — written by SessionStart hook, consumed by MCP |
+
+## Session Overlay
+
+### SessionOverlay
+
+Tracks file mutations during a session without modifying the cached index.
+
+```
+SessionOverlay
+├── created_files: Dict[str, OverlayEntry]
+├── modified_files: Dict[str, OverlayEntry]
+├── deleted_files: Set[str]
+├── _lock: threading.Lock                    # All mutations acquire lock
+│
+├── notify_file_change(path, content) → None
+├── notify_file_create(path) → None
+├── notify_file_delete(path) → None
+├── get_effective_symbols(path) → List[IvySymbol]
+├── get_effective_includes(path) → List[str]
+```
+
+**Thread safety**: All mutation methods (`notify_*`) acquire `_lock`. Read methods (`get_effective_*`) return snapshots — eventually consistent with writes. This is sufficient because LSP and MCP may run in the same process (via the `from_lsp_server` bridge in `ToolContext`).
+
+**OverlayEntry**: When a file is created or modified, it gets fast-indexed immediately (Tier 2 lexer — milliseconds):
+
+```
+OverlayEntry
+├── symbols: List[IvySymbol]
+├── includes: List[str]
+├── exports: ExportImportInfo
+├── completeness: str
+├── dirty_since: float
+```
+
+**Merge semantics**: Queries check overlay first → fall through to cached index. Include graph and test scopes recomputed lazily on view refresh.
+
+### Multiple Test Scope Views
+
+```
+TestScopeView
+├── name: str                    # User-assigned
+├── test_name: str               # Entry point
+├── protocol: str
+├── scope: TestScope             # From .ivy-index/scopes/ + overlay
+├── is_stale: bool               # True if overlay touched a file in scope
+│
+├── files_in_scope() → List[str]
+├── symbols_in_scope() → List[IvySymbol]
+├── requirements_in_scope() → List[RequirementNode]
+├── coverage_in_scope() → CoverageStats
+├── refresh() → None
+├── completeness() → "complete" | "partial" | "building"
+```
+
+Multiple views coexist within a session:
+- Agent A sees `quic_server_test_reset` scope (37 files)
+- Agent B sees `apt_quic_attacker_test` scope (52 files)
+- Both read from same `WorkspaceContext` with different scope filters
+- Views from different protocols are fully isolated (no shared files)
+
+### Incomplete Model Support
+
+For a new `protocol-testing/rpc/` being built:
+
+- **No index**: `WorkspaceContext` loads without `rpc` in `protocol_indexes`. Overlay tracks new files.
+- **Partial index**: First `ivy-lsp index` produces scopes with `"completeness": "building"` and `dangling_includes` listed.
+- **Full index**: All includes resolved, scopes become `"complete"`.
+
+Views work at every stage — they just report reduced completeness for partial models.
+
+### MCP Tool Scope Parameter
+
+MCP tools gain an optional `scope` parameter:
+
+```
+ivy_verify(file="quic_packet.ivy", scope="quic_server_test_reset")
+  → resolves via scope's layer-aware staging
+  → coverage filtered to scope's requirements
+
+ivy_coverage(scope="quic_server_test_reset")
+  → returns coverage only for files/requirements in scope
+
+ivy_diagnostics(scope="quic_server_test_reset")
+  → checks only files in scope
+```
+
+When `scope` is omitted, tools use full workspace (backward compatible).
+
+### Staging Directory Relationship
+
+The existing flat staging directory (symlinks in `/tmp/ivy-lsp-stage-*/`) is still created at **session start** from the index data — not stored in the index itself. The index provides the file-to-layer mappings; the staging directory is a runtime artifact built from those mappings. With the index loaded, staging creation is faster (no filesystem walk needed) and layer-aware (uses `known_collisions` and layer priority from `.ivyworkspace`).
+
+When a `scope` parameter is provided to MCP tools, the staging directory is filtered to only include files in that scope — preventing cross-scope collision resolution errors.
+
+## CLI Command: `ivy-lsp index`
+
+### Usage
+
+```bash
+# Index one protocol (full parser, default)
+ivy-lsp index protocol-testing/quic/
+
+# Index all protocols
+ivy-lsp index --all
+
+# Fast fallback (lexer only, when parser unavailable)
+ivy-lsp index protocol-testing/quic/ --fast
+
+# Check staleness without rebuilding
+ivy-lsp index --status
+
+# Force rebuild even if fresh
+ivy-lsp index protocol-testing/quic/ --force
+```
+
+### Build Process
+
+```
+1. Detect workspace root (canonical detect_workspace_root())
+2. Load .ivyworkspace for layer definitions
+3. Walk protocol dir — discover all .ivy files (respecting exclude_paths)
+4. For each file:
+   a. Run TieredExtractor (Tier 1 full parser by default, Tier 2 with --fast)
+   b. Collect: symbols, includes, exports, requirements, tier_used
+   c. Record: mtime, sha256, completeness
+5. Build IncludeGraph from all include edges
+6. Identify test entry points:
+   - Phase 1: use existing heuristic (`has_exports` only) to match current LSP behavior
+   - Phase 4 refinement: tighten to `has_exports AND located in *_tests/ directory`
+   (The stricter heuristic avoids false positives from behavior files with exports,
+   but is deferred to avoid divergence between offline and live indexing until the
+   live indexer is also updated to match)
+7. For each test entry point:
+   a. Compute transitive include closure (BFS on include graph)
+   b. Detect role (client/server/mim via `detect_test_role()` — inspects behavior file basenames in include closure: `server_behavior` → role=client, `client_behavior` → role=server)
+   c. Detect dangling includes (included modules with no resolved file)
+   d. Write scopes/<test_name>.json
+8. Build SemanticModel + ScopedRequirementModel
+9. Write all output to protocol-testing/<prot>/.ivy-index/
+10. Print summary
+```
+
+### MCP Tool: `ivy_index`
+
+```
+ivy_index(protocol="quic")
+ivy_index(protocol="all")
+ivy_index(protocol="quic", fast=true)
+ivy_index(status=true)
+```
+
+### Progression Path: A → D
+
+| Stage | Trigger | Implementation |
+|-------|---------|---------------|
+| **A** (this design) | Manual CLI + MCP tool | `ivy-lsp index`, `ivy_index` MCP tool |
+| **B** | Git post-commit hook | `ivy-lsp index --all --if-stale` in `.git/hooks/post-commit` |
+| **C** | Session-start auto | SessionStart hook runs `ivy-lsp index --all` if staleness > threshold |
+| **D** | Background watcher | `ivy-lsp watch` — `watchdog`/`fsevents`, incremental `.ivy-index/` updates |
+
+Index format is identical across all stages. Only the trigger mechanism changes.
+
+## Migration Path
+
+### Phase 1 — Index Builder + Loading
+
+Ship together (both are needed for testing):
+- `ivy-lsp index` CLI command
+- `WorkspaceContext.load()` with `.ivy-index/` discovery
+- If `.ivy-index/` not found: fall through to current behavior (scan from scratch)
+- No regressions for users without pre-computed indexes
+
+### Phase 2 — Unify Detection Paths
+
+- `detect-ivy-workspace.sh` simplified to thin wrapper calling `python -m ivy_lsp.workspace_context detect`
+- `start-ivy-tools.sh` reads `IVY_WORKSPACE_ROOT` from env instead of re-detecting
+- `.lsp.json` removes hardcoded env vars
+- Deprecate `IVY_LSP_INCLUDE_PATHS`, `IVY_LSP_EXCLUDE_PATHS`, `IVY_LSP_WORKSPACE_HINT`
+
+### Phase 3 — Wire MCP to Shared Index
+
+- `start_mcp()` receives `WorkspaceContext` instead of bare `workspace_root`
+- MCP tools use `ctx.resolve_include()`, `ctx.get_test_scope()`, layer-aware staging
+- Add `scope` parameter to MCP tools
+
+### Phase 4 — Session Overlay & Views
+
+- Add `SessionOverlay` for in-memory file tracking
+- Add `TestScopeView` for concurrent views
+- Expose `ivy_index` MCP tool
+
+## Testing Strategy
+
+### Unit Tests
+
+- `test_workspace_context.py` — load, staleness, error recovery, protocol isolation
+- `test_index_builder.py` — CLI produces valid `.ivy-index/`, handles partial models, correct test entry point detection
+- `test_session_overlay.py` — create/modify/delete tracking, merge with index, thread safety
+- `test_scope_views.py` — view creation, staleness, refresh, concurrent views
+- `test_migration.py` — graceful fallback when no `.ivy-index/` exists, corrupt index recovery
+
+### Integration Tests
+
+- Index `protocol-testing/quic/`, load in `WorkspaceContext`, verify symbol count matches live indexer
+- Index `protocol-testing/apt/`, verify APT's forked QUIC files are indexed independently from base QUIC
+- Index incomplete protocol (temp dir with partial files), verify dangling includes and `"building"` completeness
+- Verify protocol isolation: APT scope never references files from base QUIC index
+- MCP tool with scope: `ivy_verify(file, scope=test_name)` resolves to correct layer variant
+
+### Ground Truth Validation
+
+For each test in `protocol-testing/quic/quic_tests/`, compare `scopes/<test>.json` transitive closure against what PANTHER's `ivyc` actually includes. The offline index must produce the same file set that ivyc would use. Repeat for APT tests to verify the forked QUIC files resolve correctly within the APT index.
+
+## Success Criteria
+
+1. `ivy-lsp index --all` completes in <60s for the full 678-file workspace (profiling needed to validate; the 2-4 min current cold start includes LSP overhead not present in offline indexing)
+2. Session cold start with pre-computed index: <2s (vs current ~4 min)
+3. MCP tools with `scope` return results consistent with LSP scoped queries
+4. No regression: sessions without `.ivy-index/` work identically to today
+5. Incomplete models: overlay tracks new files, views show `"building"` status
+6. Protocol isolation: APT and base QUIC indexes are fully independent, test scopes never cross protocol boundaries
+
+## Platform Notes
+
+- File locking for concurrent index writes uses `fcntl.flock()` (Unix-only). Windows is not currently supported by PANTHER.
+- Pickle files are version-coupled to the `SemanticModel` and `ScopedRequirementModel` class structure. Any field changes invalidate cached indexes; `builder_version` mismatch triggers graceful fallback + rebuild warning.

--- a/panther/core/experiment_manager.py
+++ b/panther/core/experiment_manager.py
@@ -732,7 +732,8 @@ class ExperimentManager(
                                 self.logger.info(
                                     f"{emoji}Failed: {test_case.test_config.name} - Test analysis failed"
                                 )
-                            # Emit test failed event
+                            # Emit test failed event — TestCase.run() does not emit
+                            # failure events itself, so the manager is responsible.
                             test_specific_emitter.emit_failed(
                                 error_message="Test analysis failed",
                                 error_type="TestAnalysisFailure",
@@ -754,7 +755,9 @@ class ExperimentManager(
                                 f"{emoji}Completed: {test_case.test_config.name}"
                             )
 
-                        # Emit test completed successfully event
+                        # Emit test completed event — the manager owns emission
+                        # because TestCase.run() delegates analysis but does not
+                        # emit lifecycle events itself.
                         test_specific_emitter.emit_completed(
                             summary={
                                 "status": "success",

--- a/panther/core/observer/impl/experiment_observer.py
+++ b/panther/core/observer/impl/experiment_observer.py
@@ -47,7 +47,8 @@ class ExperimentObserver(IObserver):
     """Enhanced ExperimentObserver that monitors experiment execution and tracks experiment state.
 
     This observer handles experiment-specific events, tracks environment monitoring,
-    and provides status reporting for experiment execution.
+    and provides status reporting for experiment execution. Unhandled event types
+    are logged at DEBUG level and do not cause errors.
 
     It integrates with the global logging configuration and supports:
     - Tracking experiment state and progress
@@ -81,8 +82,10 @@ class ExperimentObserver(IObserver):
         self.observed_environments: Set[str] = set()  # Just track what we've seen
         self.observed_services: Set[str] = set()  # Just track what we've seen
 
-        # Remove all state dictionaries - state is managed centrally by StateManager
-        # These were causing orchestration behavior
+        # Removed legacy per-environment/per-service state dictionaries that
+        # duplicated orchestration concerns.  This observer now only tracks
+        # which environments/services it has *observed* (for logging) and
+        # maintains its own minimal experiment-level state below.
 
         # Set up logging using the interface method
         self.log_level = getattr(logging, log_level.upper(), logging.INFO)
@@ -96,7 +99,7 @@ class ExperimentObserver(IObserver):
             structured_output=True,
         )
 
-        # Create or update progress bar for this step
+        # Lazy-init progress tracking dict (guards against repeated __init__ calls)
         if not hasattr(self, "_step_progress_bars"):
             self._step_progress_bars = {}
 

--- a/panther/core/observer/impl/metrics_observer.py
+++ b/panther/core/observer/impl/metrics_observer.py
@@ -584,7 +584,6 @@ class MetricsObserver(ITypedObserver):
 
     def is_interested(self, event_type: str) -> bool:
         """Check if this observer is interested in metrics events."""
-        # We're interested in all metrics events
         return event_type.startswith("metrics.")
 
     def _ensure_metrics_collector(self) -> bool:

--- a/panther/core/reporting/experiment_reporter.py
+++ b/panther/core/reporting/experiment_reporter.py
@@ -126,8 +126,7 @@ class ExperimentReporter:
     """
 
     def __init__(self, experiment_dir: Path, experiment_name: Optional[str] = None):
-        """
-        Initialize experiment reporter.
+        """Initialize experiment reporter.
 
         Args:
             experiment_dir: Path to experiment output directory
@@ -145,15 +144,16 @@ class ExperimentReporter:
                 loader=FileSystemLoader(templates_dir),
                 trim_blocks=True,
                 lstrip_blocks=True,
-                autoescape=True,
+                # Templates produce Markdown, not HTML — autoescape would
+                # corrupt <, >, & in variable content.
+                autoescape=False,
             )
         else:
             self.jinja_env = None
             self.logger.warning("Jinja2 not available - using basic templates")
 
     def generate_reports(self) -> Dict[str, bool]:
-        """
-        Generate all experiment reports.
+        """Generate all experiment reports.
 
         Returns:
             Dict[str, bool]: Success status for each report type
@@ -321,13 +321,20 @@ class ExperimentReporter:
                     if svcs:
                         lines.append(f"### {label} ({len(svcs)})")
                         lines.append(
-                            "| Service | Status | Compilation | Exit Code | Errors |"
+                            "| Service | Status | Compilation | Phases | Exit Code | Errors |"
                         )
                         lines.append(
-                            "|---------|--------|-------------|-----------|--------|"
+                            "|---------|--------|-------------|--------|-----------|--------|"
                         )
                         for svc in svcs:
                             comp = "OK" if svc.compilation_succeeded else "FAIL"
+                            if svc.phases_completed:
+                                done = sum(
+                                    1 for v in svc.phases_completed.values() if v
+                                )
+                                phases = f"{done}/{len(svc.phases_completed)}"
+                            else:
+                                phases = "N/A"
                             ec = (
                                 str(svc.exit_code)
                                 if svc.exit_code is not None
@@ -335,7 +342,7 @@ class ExperimentReporter:
                             )
                             err = svc.error_summary or "None"
                             lines.append(
-                                f"| {svc.service_name} | {svc.status} | {comp} | {ec} | {err} |"
+                                f"| {svc.service_name} | {svc.status} | {comp} | {phases} | {ec} | {err} |"
                             )
                         lines.append("")
 
@@ -518,8 +525,7 @@ class ExperimentReporter:
         return "Development"
 
     def generate_quick_summary(self) -> Optional[str]:
-        """
-        Generate a quick one-line summary for logging.
+        """Generate a quick one-line summary for logging.
 
         Returns:
             str: Quick summary string

--- a/panther/core/reporting/status_collector.py
+++ b/panther/core/reporting/status_collector.py
@@ -117,6 +117,8 @@ class ServiceHealthSummary:
     phases_completed: Optional[Dict[str, bool]] = None
     error_summary: Optional[str] = None
     output_completeness: float = 0.0
+    # Retained for JSON serialization (included via asdict in to_dict)
+    # even though no template currently renders it.
     test_name: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
@@ -582,7 +584,9 @@ class StatusCollector:
         end_time = None
         duration = 0.0
 
-        # Extract start time (first log entry)
+        # Extract start time from the first log entry.  This includes
+        # initialization overhead (not just test execution), which is
+        # intentional — the log reflects wall-clock elapsed time.
         if lines:
             start_match = re.search(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", lines[0])
             if start_match:

--- a/panther/core/reporting/templates/experiment_report.md.jinja
+++ b/panther/core/reporting/templates/experiment_report.md.jinja
@@ -134,21 +134,21 @@
 This experiment failed. Key points to investigate:
 
 {%- if summary.fast_fail.triggered %}
-1. **Fast-fail was triggered**: {{ summary.fast_fail.reason }}
+- **Fast-fail was triggered**: {{ summary.fast_fail.reason }}
 {%- if summary.fast_fail.error_category %}
-   - Error category: {{ summary.fast_fail.error_category }}
+  - Error category: {{ summary.fast_fail.error_category }}
 {%- endif %}
 {%- endif %}
 
 {%- set failed_tests = summary.tests|rejectattr("status.value", "equalto", "passed")|list %}
 {%- if failed_tests %}
-2. **Failed tests to investigate**:
+- **Failed tests to investigate**:
 {%- for test in failed_tests %}
-   - {{ test.name }}: Check `./{{ test.logs_path }}/test.log`
+  - {{ test.name }}: Check `./{{ test.logs_path }}/test.log`
 {%- endfor %}
 {%- endif %}
 
-3. **Next steps**:
+- **Next steps**:
    - Review the main experiment log: `./experiment.log`
    - Check individual test logs for detailed error information
    - Verify configuration parameters in `experiment_config.yaml`

--- a/panther/core/reporting/templates/experiment_report.md.jinja
+++ b/panther/core/reporting/templates/experiment_report.md.jinja
@@ -54,7 +54,7 @@
 | Service | Status | Compilation | Phases | Exit Code | Errors |
 |---------|--------|-------------|--------|-----------|--------|
 {% for svc in iut_services %}
-| {{ svc.service_name }} | {{ svc.status }} | {{ 'OK' if svc.compilation_succeeded else 'FAIL' }} | {{ svc.phases_completed.values()|select|list|length }}/{{ svc.phases_completed|length }} | {{ svc.exit_code if svc.exit_code is not none else 'N/A' }} | {{ svc.error_summary or 'None' }} |
+| {{ svc.service_name }} | {{ svc.status }} | {{ 'OK' if svc.compilation_succeeded else 'FAIL' }} | {{ (svc.phases_completed.values()|select|list|length ~ '/' ~ svc.phases_completed|length) if svc.phases_completed else 'N/A' }} | {{ svc.exit_code if svc.exit_code is not none else 'N/A' }} | {{ svc.error_summary or 'None' }} |
 {%- endfor %}
 {%- endif %}
 
@@ -63,7 +63,7 @@
 | Service | Status | Compilation | Phases | Exit Code | Errors |
 |---------|--------|-------------|--------|-----------|--------|
 {% for svc in tester_services %}
-| {{ svc.service_name }} | {{ svc.status }} | {{ 'OK' if svc.compilation_succeeded else 'FAIL' }} | {{ svc.phases_completed.values()|select|list|length }}/{{ svc.phases_completed|length }} | {{ svc.exit_code if svc.exit_code is not none else 'N/A' }} | {{ svc.error_summary or 'None' }} |
+| {{ svc.service_name }} | {{ svc.status }} | {{ 'OK' if svc.compilation_succeeded else 'FAIL' }} | {{ (svc.phases_completed.values()|select|list|length ~ '/' ~ svc.phases_completed|length) if svc.phases_completed else 'N/A' }} | {{ svc.exit_code if svc.exit_code is not none else 'N/A' }} | {{ svc.error_summary or 'None' }} |
 {%- endfor %}
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
## Summary
- **C1 fix**: Guard `phases_completed=None` in `experiment_report.md.jinja` (lines 57, 66) — `.values()` was called on `None` when services lack phase data, causing TypeError and silent fallback to basic markdown renderer
- Updates `panther_ivy` submodule with:
  - 6 rfc9000 requirements section-key alignment fixes
  - ivy-lsp gitignore for temp dir leakage
  - panther-ivy-plugin LSP env config in marketplace.json, version bump, hook scoping
  - classify_endpoint_type segment-based matching fix
  - .ivyworkspace v2 with scope_detection: auto

## Test plan
- [ ] Verify Jinja template renders correctly with `phases_completed=None` (returns "N/A")
- [ ] Verify Jinja template renders correctly with valid dict (returns "2/3" format)
- [ ] Run `pytest tests/unit/ -n auto -m unit` — expect 1084+ passed, no new regressions
- [ ] Confirm `classify_endpoint_type("quic_client_test_0rtt_mim_replay", "server")` returns `"client"`

## Summary by Sourcery

Handle missing phase data safely in experiment reports, adjust Jinja environment for Markdown output, and update Ivy-related documentation and comments for clarity.

Bug Fixes:
- Prevent crashes in experiment report Jinja template when service phase data is missing or None by rendering a fallback value instead.

Enhancements:
- Include a phases summary column in the basic Markdown experiment report output, showing completed vs total phases or N/A when unavailable.
- Disable Jinja autoescaping for Markdown experiment templates to avoid corrupting rendered variable content.
- Clarify observer, experiment manager, status collector, and metrics observer behavior via improved comments and docstrings around state tracking, event emission, and timing semantics.

Documentation:
- Add a detailed Ivy tooling ecosystem evaluation document under docs/superpowers/specs to capture current capabilities and gaps.